### PR TITLE
Fixed missing usage of tag prefix

### DIFF
--- a/generate-docker-image-tags/action.yml
+++ b/generate-docker-image-tags/action.yml
@@ -53,7 +53,7 @@ runs:
         then
           TAGS="latest,$BRANCH,$COMMIT_SHA"
         else
-          TAGS="${{ inputs.prefix }}.$BRANCH,dev.$COMMIT_SHA"
+          TAGS="${{ inputs.prefix }}.$BRANCH,${{ inputs.prefx }}.$COMMIT_SHA"
         fi
 
         printf "::set-output name=tags::$TAGS"


### PR DESCRIPTION
# Changes
- `generate-docker-image-tags` was missing a usage of the `prefix` parameter, fixed