### PR TITLE
Add pinned comment action

### DIFF
--- a/pinned-pull-request-comment/README.md
+++ b/pinned-pull-request-comment/README.md
@@ -4,3 +4,62 @@ This action enabled you to have *pinned* comments on pull requests.
 
 "pinned" in this case means updating an existing comment instead of creating a new 
 comment each time from GitHub Actions.
+
+
+## Creating a pinned comment
+```yaml
+- uses: XanaduAI/cloud-actions/pinned-pull-request-comment@main
+  with:
+     github_token: ${{ github.token }}
+     pull_request_number: ${{ github.event.pull_request.number }}
+     comment_body: |
+      **Sample pinned comment**
+      Thank you for opening this PR.
+```
+
+## Updating comments with results
+```yaml
+- id: results
+  uses: my-action/results@v1
+ 
+- uses: XanaduAI/cloud-actions/pinned-pull-request-comment@main
+  with:
+     github_token: ${{ github.token }}
+     pull_request_number: ${{ github.event.pull_request.number }}
+     comment_body: |
+      *Results are*: ${{ steps.results.outputs.result }}
+```
+
+## Managing multiple sticky comments
+The `pinned_comment_uid` is an arbitrary string that you can use to manage multiple
+pinned comments. 
+
+**NOTE:** Updating this parameter will always generate a new comment
+
+```yaml
+- id: resultsA
+  uses: my-action/results@v1
+  with:
+    param: A
+
+- id: resultsB
+  uses: my-action/results@v1
+  with:
+    param: B
+ 
+- uses: XanaduAI/cloud-actions/pinned-pull-request-comment@main
+  with:
+     github_token: ${{ github.token }}
+     pinned_comment_uid: resultA
+     pull_request_number: ${{ github.event.pull_request.number }}
+     comment_body: |
+      *Results are*: ${{ steps.resultsA.outputs.result }}
+
+- uses: XanaduAI/cloud-actions/pinned-pull-request-comment@main
+  with:
+     github_token: ${{ github.token }}
+     pinned_comment_uid: resultB
+     pull_request_number: ${{ github.event.pull_request.number }}
+     comment_body: |
+      *Results are*: ${{ steps.resultsB.outputs.result }}
+```

--- a/pinned-pull-request-comment/README.md
+++ b/pinned-pull-request-comment/README.md
@@ -1,0 +1,6 @@
+# Pinned Pull Request Comment
+
+This action enabled you to have *pinned* comments on pull requests.
+
+"pinned" in this case means updating an existing comment instead of creating a new 
+comment each time from GitHub Actions.

--- a/pinned-pull-request-comment/action.yml
+++ b/pinned-pull-request-comment/action.yml
@@ -1,0 +1,32 @@
+name: Pinned Pull Request Comment
+description: Create and manage pinned comments on pull requests.
+
+inputs:
+  pull_request_number:
+    description: The pull request number on which a comment needs to be added or updated
+    required: true
+  pinned_comment_uid:
+    description: |
+      A Unique identifier to use to track a pinned comment. Can be set to an arbitrary value.
+      Use this input if you wan to manage multiple pinned comments on the same pull request.
+      Pass a different id for each of the comments you want to pin and manage.
+      Alternatively, if you want a net-new comment each time and want to disable pinning,
+      set this input to an empty string
+    required: false
+    default: default-pinned-comment
+  comment_body:
+    description: The content of the comment
+    required: true
+  github_token:
+    description: The GITHUB_TOKEN. Must have access to post comments on pull requests.
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - uses: actions/github-script@v6
+      with:
+        github-token: ${{ inputs.github_token }}
+        script: |
+          const script = require('${{ github.action_path }}/comment.js');
+          await script({github, context}, ${{ inputs.pull_request_number }}, "${{ inputs.pinned_comment_uid }}", `${{ inputs.comment_body }}`);

--- a/pinned-pull-request-comment/comment.js
+++ b/pinned-pull-request-comment/comment.js
@@ -1,0 +1,35 @@
+module.exports = async ({github, context}, prNumber, commentUid, commentBody) => {
+    // Static User ID of the GitHub Actions Bot
+    // Sample Reference: https://github.com/orgs/community/discussions/26560
+    const actionsBotUserId = 41898282;
+
+    const commentHeader = `<!-- ${commentUid} -->`;
+    const commentContent = `${commentBody}\n${commentHeader}`;
+    console.log(commentContent);
+
+    const opts = github.rest.issues.listComments.endpoint.merge({
+        owner: context.repo.owner,
+        repo: context.repo.repo,
+        issue_number: prNumber
+    });
+    const comments = await github.paginate(opts);
+
+    // Find any comment already made by the bot.
+    const botComment = comments.find(comment => comment.user.id === actionsBotUserId && comment.body.trim().endsWith(commentHeader));
+
+    if (botComment && commentUid) {
+        await github.rest.issues.updateComment({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            comment_id: botComment.id,
+            body: commentContent
+        });
+    } else {
+        await github.rest.issues.createComment({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            issue_number: prNumber,
+            body: commentContent
+        });
+    }
+}


### PR DESCRIPTION
Add a new action that allows you to manage 1 or more "pinned" comments on a pull request.

Pinned in this case means a comment that you update instead of creating a new comment each time.

Sample usecases documented in the README.