### PR TITLE
Derive PR numbers correctly on `push` events

### DIFF
--- a/generate-docker-image-tags/action.yml
+++ b/generate-docker-image-tags/action.yml
@@ -60,9 +60,21 @@ runs:
           TAGS="${{ inputs.prefix }}.$BRANCH,${{ inputs.prefix }}.$COMMIT_SHA"
         fi
 
+        if [ "$GITHUB_EVENT_NAME" == "pull_request" ]
+        then
+          PR_NUMBER=${{ github.event.number }}
+        else
+          # Workflow was triggered by a "push" event.
+          PR_NUMBER=$(
+            echo "${{ github.event.head_commit.message }}" \
+            | grep -o "(#[0-9]*)" \
+            | sed 's/[#()]//g'
+          )
+        fi
+
         # Add additional tags for each Story ID associated with this PR.
-        if [ ! -z "${{ inputs.shortcut-api-token }}" ]; then
-          url="$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/pull/${{ github.event.number }}"
+        if [ ! -z "$PR_NUMBER" ] && [ ! -z "${{ inputs.shortcut-api-token }}" ]; then
+          url="$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/pull/$PR_NUMBER"
 
           ids=$(
             curl --silent -X GET \
@@ -74,7 +86,9 @@ runs:
           )
 
           while read -r id; do
-            TAGS="$TAGS,sc-$id"
+            if [ ! -z "$id" ]; then
+              TAGS="$TAGS,sc-$id"
+            fi
           done <<< "$ids"
         fi
 


### PR DESCRIPTION
**Stories:**

* [sc-27060]

**Changes:**

* Updated the Generate Docker Image Tags action to correctly derive PR numbers on `push` events. 

**Note:**

* Check out the Story comments for links to GitHub Actions runs showing the new Action in action. 