### PR TITLE
Parallelize building and pushing Docker images

### DIFF
--- a/build-docker-images/action.yml
+++ b/build-docker-images/action.yml
@@ -1,0 +1,31 @@
+name: Build Docker Images
+description: Builds multiple Docker images in parallel (using BuildKit).
+
+inputs:
+  path:
+    description: Docker build context path (e.g., "."").
+    required: true
+  targets:
+    description: Docker build targets as a space-separated list (e.g., "daemon server").
+    required: true
+  docker-build-extra-args:
+    description: Docker build extra arguments (e.g., "ssh=default").
+    required: false
+
+runs:
+  using: composite
+  steps:
+    - shell: bash
+      run: |
+        for target in ${{ inputs.targets }}; do
+          DOCKER_BUILDKIT=1 \
+            docker build \
+              --build-arg COMMIT_SHA=${{ github.sha }} \
+              --ssh default \
+              --tag target \
+              --target target \
+              ${{ inputs.docker-build-extra-args }} \
+              . &
+        done
+
+        wait

--- a/build-docker-images/action.yml
+++ b/build-docker-images/action.yml
@@ -22,8 +22,8 @@ runs:
             docker build \
               --build-arg COMMIT_SHA=${{ github.sha }} \
               --ssh default \
-              --tag target \
-              --target target \
+              --tag $target \
+              --target $target \
               ${{ inputs.docker-build-extra-args }} \
               . &
         done

--- a/build-docker-images/action.yml
+++ b/build-docker-images/action.yml
@@ -1,15 +1,17 @@
 name: Build Docker Images
-description: Builds multiple Docker images in parallel (using BuildKit).
+description: >
+  Builds multiple Docker images in parallel (with BuildKit enabled).
+  Each Docker image will be tagged with the name of its target.
 
 inputs:
   path:
-    description: Docker build context path (e.g., "."").
+    description: Docker build context path (e.g., ".").
     required: true
   targets:
     description: Docker build targets as a space-separated list (e.g., "daemon server").
     required: true
   docker-build-extra-args:
-    description: Docker build extra arguments (e.g., "ssh=default").
+    description: Docker build extra arguments.
     required: false
 
 runs:

--- a/push-docker-images/action.yml
+++ b/push-docker-images/action.yml
@@ -37,7 +37,7 @@ runs:
             target="${repo}:${tag}"
 
             docker tag $image $target
-            docker push $target & .
+            docker push $target &
           done
         done
 

--- a/push-docker-images/action.yml
+++ b/push-docker-images/action.yml
@@ -1,0 +1,37 @@
+name: Push Docker Images
+description: Pushes multiple Docker images in parallel.
+
+inputs:
+  images:
+    description: Docker images to push as a space-separated list (local tags or IDs).
+    required: true
+  repos:
+    description: >
+      Docker image repositories (to push the images to) as a space-separated list.
+      The number of repositories must match the number of images.
+    required: true
+  tags:
+    description: Tags to apply to the pushed Docker images as a comma-separated list.
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - shell: bash
+      run: |
+        read -ra images <<< "${{ inputs.images }}"
+        read -ra repos <<< "${{ inputs.repos }}"
+        ITF="," read -ra tags <<< "${{ inputs.tags }}"
+
+        for i in "${!images[@]}"; do
+          for tag in "${tags[@]}"; do
+            image="${images[$i]}"
+            repo="${repos[$i]}"
+            target="${repo}:${tag}"
+
+            docker tag $image $target
+            docker push $target & .
+          done
+        done
+
+        wait

--- a/push-docker-images/action.yml
+++ b/push-docker-images/action.yml
@@ -3,7 +3,9 @@ description: Pushes multiple Docker images in parallel.
 
 inputs:
   images:
-    description: Docker images to push as a space-separated list (local tags or IDs).
+    description: >
+      Docker images to push (local tags or IDs) as a space-separated list.
+      The number of images must match the number of repositories.
     required: true
   repos:
     description: >
@@ -21,7 +23,12 @@ runs:
       run: |
         read -ra images <<< "${{ inputs.images }}"
         read -ra repos <<< "${{ inputs.repos }}"
-        ITF="," read -ra tags <<< "${{ inputs.tags }}"
+        IFS="," read -ra tags <<< "${{ inputs.tags }}"
+
+        if [ "${#images[@]}" -ne "${#repos[@]}" ]; then
+          echo "Number of images must match the number of repositories."
+          exit 1
+        fi
 
         for i in "${!images[@]}"; do
           for tag in "${tags[@]}"; do

--- a/push-docker-images/action.yml
+++ b/push-docker-images/action.yml
@@ -31,14 +31,14 @@ runs:
         fi
 
         for i in "${!images[@]}"; do
-          for tag in "${tags[@]}"; do
-            image="${images[$i]}"
-            repo="${repos[$i]}"
-            target="${repo}:${tag}"
+          image="${images[$i]}"
+          repo="${repos[$i]}"
 
-            docker tag $image $target
-            docker push $target &
+          for tag in "${tags[@]}"; do
+            docker tag $image $repo:$tag
           done
+
+          docker push --all-tags $repo &
         done
 
         wait


### PR DESCRIPTION
This PR contributes two new Actions:
* **Build Docker Images**: Extension of `build-docker-image` which builds Docker images in parallel.
* **Push Docker Images**: Extension of `push-docker-image` which pushes Docker images in parallel.