### PR TITLE
Add aws retry attempts

### DIFF
--- a/push-to-s3-and-invalidate-cloudfront/README.md
+++ b/push-to-s3-and-invalidate-cloudfront/README.md
@@ -6,7 +6,7 @@ Files are pushed to the S3 bucket depending on the user inputs supplied when the
 Following examples describe how to use the action.
 
 ## Uploading to S3 based on user input
-This example will **upload** the specified folder (`build-directory`) to a folder named `blog` on the S3 bucket(`myS3Bucket`). The action will not exclude any files while uploading them. The action will also invalidate the cloudfront cache. The action will attempt a max of `5` (based on user input) retries for any AWS operations before erroring out.
+This example will **upload** the specified folder (`build-directory`) to a folder named `blog` on the S3 bucket(`myS3Bucket`). The action will not exclude any files while uploading them. The action will also invalidate the cloudfront cache. The action will attempt a max of `5` (based on `aws-retry-attempts` value) retries for any AWS operations before erroring out.
 
 ```yaml
 - uses: XanaduAI/cloud-actions/push-to-s3-and-invalidate-cloudfront@main

--- a/push-to-s3-and-invalidate-cloudfront/README.md
+++ b/push-to-s3-and-invalidate-cloudfront/README.md
@@ -26,7 +26,8 @@ This example will **upload** the specified folder (`build-directory`) to a folde
 ```
 
 ## Deleting from S3 based on user input
-This example will **delete** the specified folder (`build-directory`) from the S3 bucket(`myS3Bucket`). The action will also invalidate the cloudfront cache. The action will attempt a max of `5` (based on user input) retries for any AWS operations before erroring out.
+This example will **delete** the specified folder (`build-directory`) from the S3 bucket(`myS3Bucket`). The action will also invalidate the cloudfront cache.  The action will attempt a max of `5` (based on `aws-retry-attempts` value) retries for any AWS operations before erroring out.
+
 
 ```yaml
 - uses: XanaduAI/cloud-actions/push-to-s3-and-invalidate-cloudfront@main

--- a/push-to-s3-and-invalidate-cloudfront/README.md
+++ b/push-to-s3-and-invalidate-cloudfront/README.md
@@ -6,7 +6,7 @@ Files are pushed to the S3 bucket depending on the user inputs supplied when the
 Following examples describe how to use the action.
 
 ## Uploading to S3 based on user input
-This example will **upload** the specified folder (`build-directory`) to a folder named `blog` on the S3 bucket(`myS3Bucket`). The action will not exclude any files while uploading them. The action will also invalidate the cloudfront cache.
+This example will **upload** the specified folder (`build-directory`) to a folder named `blog` on the S3 bucket(`myS3Bucket`). The action will not exclude any files while uploading them. The action will also invalidate the cloudfront cache. The action will attempt a max of `5` (based on user input) retries for any AWS operations before erroring out.
 
 ```yaml
 - uses: XanaduAI/cloud-actions/push-to-s3-and-invalidate-cloudfront@main
@@ -22,10 +22,11 @@ This example will **upload** the specified folder (`build-directory`) to a folde
     s3-dir-to-upload-to: "blog"
     s3-files-to-exclude: ""
     invalidate-cloudfront-cache: "true"
+    aws-retry-attempts: 5
 ```
 
 ## Deleting from S3 based on user input
-This example will **delete** the specified folder (`build-directory`) from the S3 bucket(`myS3Bucket`). The action will also invalidate the cloudfront cache.
+This example will **delete** the specified folder (`build-directory`) from the S3 bucket(`myS3Bucket`). The action will also invalidate the cloudfront cache. The action will attempt a max of `5` (based on user input) retries for any AWS operations before erroring out.
 
 ```yaml
 - uses: XanaduAI/cloud-actions/push-to-s3-and-invalidate-cloudfront@main
@@ -40,12 +41,14 @@ This example will **delete** the specified folder (`build-directory`) from the S
     s3-action: "delete"
     s3-dir-to-delete-from: "blog"
     invalidate-cloudfront-cache: "true"
+    aws-retry-attempts: 5
 ```
 
 ## Uploading/Deleting to/from S3 with minimal user unput
 If this action is called when a `pull_request` is `opened` or `syncronized`, then the example will **upload** the specified folder (`build-directory`) to a folder named `pr-previews/PR-123` on the S3 bucket (`myS3Bucket`). The action will exclude any files that start with the default `pr-previews` prefix. The action will not invalidate the cloudfront cache.
 
 If this action is called when a `pull_request` is `closed`, then the example will **delete** the folder named `pr-previews/PR-123` on the S3 bucket (`myS3Bucket`).
+The action will attempt a max of `2` (default) retries for any AWS operations before erroring out.
 
 ```yaml
 - uses: XanaduAI/cloud-actions/push-to-s3-and-invalidate-cloudfront@main

--- a/push-to-s3-and-invalidate-cloudfront/action.yml
+++ b/push-to-s3-and-invalidate-cloudfront/action.yml
@@ -50,6 +50,12 @@ inputs:
     description: A flag to indicate if the cloudfront cache should be invalidated
     required: false
     default: "false"
+  aws-retry-attempts:
+    description: |
+      The number of retries to perform an AWS action. 
+      Refer to https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-retries.html for the usage of retry retry attempts
+    required: false
+    default: "2"
 
 outputs:
   dir_name:
@@ -110,6 +116,7 @@ runs:
         AWS_REGION: ${{ inputs.aws-region }}
         AWS_ACCESS_KEY_ID: ${{ inputs.aws-access-key-id }}
         AWS_SECRET_ACCESS_KEY: ${{ inputs.aws-secret-access-key }}
+        AWS_MAX_ATTEMPTS: $${{ inputs.aws-retry-attempts }}
       run: |
         aws s3 sync ${{ inputs.build-directory }}/ s3://${{ inputs.s3-bucket }}/${{ steps.directory.outputs.dir_name }} ${{ steps.exclude.outputs.files_to_exlude }}
 
@@ -120,6 +127,7 @@ runs:
         AWS_REGION: ${{ inputs.aws-region }}
         AWS_ACCESS_KEY_ID: ${{ inputs.aws-access-key-id }}
         AWS_SECRET_ACCESS_KEY: ${{ inputs.aws-secret-access-key }}
+        AWS_MAX_ATTEMPTS: $${{ inputs.aws-retry-attempts }}
       run: aws s3 rm s3://${{ inputs.s3-bucket }}/${{ steps.directory.outputs.dir_name }}/ --recursive ${{ steps.exclude.outputs.files_to_exlude }}
 
     - name: Invalidate the cloudfront cache
@@ -129,5 +137,6 @@ runs:
         AWS_REGION: ${{ inputs.aws-region }}
         AWS_ACCESS_KEY_ID: ${{ inputs.aws-access-key-id }}
         AWS_SECRET_ACCESS_KEY: ${{ inputs.aws-secret-access-key }}
+        AWS_MAX_ATTEMPTS: $${{ inputs.aws-retry-attempts }}
       run: |
         aws cloudfront create-invalidation --distribution-id ${{ inputs.aws-cloudfront-distribution-id }} --paths "/${{ steps.directory.outputs.dir_name }}/*"

--- a/push-to-s3-and-invalidate-cloudfront/action.yml
+++ b/push-to-s3-and-invalidate-cloudfront/action.yml
@@ -116,7 +116,7 @@ runs:
         AWS_REGION: ${{ inputs.aws-region }}
         AWS_ACCESS_KEY_ID: ${{ inputs.aws-access-key-id }}
         AWS_SECRET_ACCESS_KEY: ${{ inputs.aws-secret-access-key }}
-        AWS_MAX_ATTEMPTS: $${{ inputs.aws-retry-attempts }}
+        AWS_MAX_ATTEMPTS: ${{ inputs.aws-retry-attempts }}
       run: |
         aws s3 sync ${{ inputs.build-directory }}/ s3://${{ inputs.s3-bucket }}/${{ steps.directory.outputs.dir_name }} ${{ steps.exclude.outputs.files_to_exlude }}
 
@@ -127,7 +127,7 @@ runs:
         AWS_REGION: ${{ inputs.aws-region }}
         AWS_ACCESS_KEY_ID: ${{ inputs.aws-access-key-id }}
         AWS_SECRET_ACCESS_KEY: ${{ inputs.aws-secret-access-key }}
-        AWS_MAX_ATTEMPTS: $${{ inputs.aws-retry-attempts }}
+        AWS_MAX_ATTEMPTS: ${{ inputs.aws-retry-attempts }}
       run: aws s3 rm s3://${{ inputs.s3-bucket }}/${{ steps.directory.outputs.dir_name }}/ --recursive ${{ steps.exclude.outputs.files_to_exlude }}
 
     - name: Invalidate the cloudfront cache
@@ -137,6 +137,6 @@ runs:
         AWS_REGION: ${{ inputs.aws-region }}
         AWS_ACCESS_KEY_ID: ${{ inputs.aws-access-key-id }}
         AWS_SECRET_ACCESS_KEY: ${{ inputs.aws-secret-access-key }}
-        AWS_MAX_ATTEMPTS: $${{ inputs.aws-retry-attempts }}
+        AWS_MAX_ATTEMPTS: ${{ inputs.aws-retry-attempts }}
       run: |
         aws cloudfront create-invalidation --distribution-id ${{ inputs.aws-cloudfront-distribution-id }} --paths "/${{ steps.directory.outputs.dir_name }}/*"

--- a/push-to-s3-and-invalidate-cloudfront/action.yml
+++ b/push-to-s3-and-invalidate-cloudfront/action.yml
@@ -52,7 +52,7 @@ inputs:
     default: "false"
   aws-retry-attempts:
     description: |
-      The number of retries to perform an AWS action. 
+      The number of retries to perform an AWS action. If unspecified will default to 2 retires.
       Refer to https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-retries.html for the usage of retry retry attempts
     required: false
     default: "2"


### PR DESCRIPTION
This PR adds an optional input to configure the retry attempts for any AWS operations for the `push-to-s3-and-invalidate-cloudfront` action