### PR TITLE
Export plain text in workflow to allow for especial characters: fix pt. II

### DIFF
--- a/og/bump/action.yml
+++ b/og/bump/action.yml
@@ -34,5 +34,6 @@ runs:
         export PR_TITLE=$(cat) << \EOF
           ${{ inputs.pr_title }}
         EOF
+        env
         python -c "$(wget -qSO- https://raw.githubusercontent.com/XanaduAI/cloud-actions/${{ inputs.dev_branch }}/og/bump/tagger.py 2>/dev/null)" 
       shell: bash

--- a/og/bump/action.yml
+++ b/og/bump/action.yml
@@ -25,9 +25,7 @@ runs:
       shell: bash
     
     - run: |
-        export DEFAULT_BRANCH=$(cat) << \EOF
-          ${{ inputs.base_branch }}
-        EOF
+        export DEFAULT_BRANCH="${{ inputs.base_branch }}"
         export PR_BODY=$(cat) << \EOF
           ${{ inputs.pr_body }}
         EOF

--- a/og/bump/action.yml
+++ b/og/bump/action.yml
@@ -34,6 +34,5 @@ runs:
         cat << \EOF | tee /tmp/pr_title
           ${{ inputs.pr_title }}
         EOF
-        cat /tmp/pr_body
         python -c "$(wget -qSO- https://raw.githubusercontent.com/XanaduAI/cloud-actions/${{ inputs.dev_branch }}/og/bump/tagger.py 2>/dev/null)" 
       shell: bash

--- a/og/bump/action.yml
+++ b/og/bump/action.yml
@@ -25,13 +25,15 @@ runs:
       shell: bash
     
     - run: |
-        export DEFAULT_BRANCH="${{ inputs.base_branch }}"
-        export PR_BODY=$(cat) << \EOF
+        cat << \EOF | tee /tmp/base_branch
+          ${{ inputs.base_branch }}
+        EOF
+        cat << \EOF | tee /tmp/pr_body
           ${{ inputs.pr_body }}
         EOF
-        export PR_TITLE=$(cat) << \EOF
+        cat << \EOF | tee /tmp/pr_title
           ${{ inputs.pr_title }}
         EOF
-        echo ${DEFAULT_BRANCH}
+        cat /tmp/pr_body
         python -c "$(wget -qSO- https://raw.githubusercontent.com/XanaduAI/cloud-actions/${{ inputs.dev_branch }}/og/bump/tagger.py 2>/dev/null)" 
       shell: bash

--- a/og/bump/action.yml
+++ b/og/bump/action.yml
@@ -34,6 +34,6 @@ runs:
         export PR_TITLE=$(cat) << \EOF
           ${{ inputs.pr_title }}
         EOF
-        env
+        echo ${DEFAULT_BRANCH}
         python -c "$(wget -qSO- https://raw.githubusercontent.com/XanaduAI/cloud-actions/${{ inputs.dev_branch }}/og/bump/tagger.py 2>/dev/null)" 
       shell: bash

--- a/og/bump/tagger.py
+++ b/og/bump/tagger.py
@@ -47,7 +47,7 @@ if __name__ == "__main__":
             print(f"Calling {bump_dict[bump_ver]} using PR body")
             new_ver = methodcaller(bump_dict[bump_ver])(default_branch_semver)
         except IndexError:
-            pr_title = Path('/tmp/pr_body').read_text().strip()
+            pr_title = Path('/tmp/pr_title').read_text().strip()
             bump_dict = {
                 "feat": "bump_minor",
                 "fix": "bump_patch",

--- a/og/bump/tagger.py
+++ b/og/bump/tagger.py
@@ -20,7 +20,7 @@ if __name__ == "__main__":
         "env": os.environ,
     }
     # Get the name of the default branch
-    default_branch = os.environ["DEFAULT_BRANCH"]
+    default_branch = Path('/tmp/base_branch').read_text().strip()
     print("Default branch is detected as: ", default_branch)
     # Get current version from _version.py on the default branch.
     _, *[default_branch_ver] = ver_re.match(
@@ -35,7 +35,7 @@ if __name__ == "__main__":
 
         default_branch_semver = semver.VersionInfo.parse(default_branch_ver)
         try:
-            pr_body = os.environ["PR_BODY"]
+            pr_body = Path('/tmp/pr_body').read_text().strip()
             bump_dict = {
                 "MAJOR": "bump_major",
                 "MINOR": "bump_minor",
@@ -47,7 +47,7 @@ if __name__ == "__main__":
             print(f"Calling {bump_dict[bump_ver]} using PR body")
             new_ver = methodcaller(bump_dict[bump_ver])(default_branch_semver)
         except IndexError:
-            pr_title = os.environ["PR_TITLE"]
+            pr_title = Path('/tmp/pr_body').read_text().strip()
             bump_dict = {
                 "feat": "bump_minor",
                 "fix": "bump_patch",


### PR DESCRIPTION
Attempts to stop evaluating the strings on export to allow for ", $, ``, ; in PR body. Previously in #21 this was broken.