### PR TITLE
Add workflow artifact download

### DIFF
--- a/download-github-workflow-artifact/README.md
+++ b/download-github-workflow-artifact/README.md
@@ -4,3 +4,63 @@ This action allows the calling action to download workflow artifacts from other 
 are attempting to download artifacts between different jobs within the same workflow, use [actions/download-artifact](https://github.com/actions/download-artifact).
 
 
+## Sample Usage
+#### Workflow being triggered by `workflow_run`
+There is a likely scenario where GitHub Actions workflowA runs successfully, creates some artifacts and then finishes
+as successful. The completion of that workflow now starts workflowB as workflowB has [on.workflow_run](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#workflow_run)
+event trigger setup.
+
+This workflowB however, needs access to the artifacts created by workflowA. This can be achieved as shown:
+```yaml
+- uses: XanaduAI/cloud-actions/download-github-workflow-artifact@main
+  with:
+    workflow_run_id: ${{ github.event.workflow_run.id }}
+    github_token: ${{ github.token }}
+```
+This will download the artifacts from the original workflow into the current workflows github workspace.
+
+**Download only certain artifacts**
+You can pass a regex to match names of artifacts you want to download using the `artifact_name_regex` input.
+
+Using the above example again:
+```yaml
+- uses: XanaduAI/cloud-actions/download-github-workflow-artifact@main
+  with:
+    workflow_run_id: ${{ github.event.workflow_run.id }}
+    artifact_name_regex: ^html\-.*$
+    github_token: ${{ github.token }}
+```
+This will download only the artifacts that begin with `html-`.
+
+#### Downloading workflows from a different workflow (can be same or separate repo)
+Let's say your workflow is not triggered by another workflow, but needs to download artifacts from another run
+of a workflow. The most difficult part of this is getting the workflow id. However, that is attainable using GitHub's
+rest api `listWorkflowRuns`.
+
+The following code snippet get the most recent successful build of a workflow, then returns the workflow id
+```yaml
+- name: Get Workflow run ID
+  id: workflow_run_id
+  uses: actions/github-script@v6
+  with:
+    result-encoding: string
+    script: |
+      const workflowRuns = await github.paginate(github.rest.actions.listWorkflowRuns.endpoint.merge({
+        owner: context.repo.owner,
+        repo: context.repo.repo,
+        workflow_id: 'workflow_you_want.yml',
+        branch: 'branch-that-workflow-ran-on',
+        event: 'event-that-triggered-that-workflow ("push", "pull_request", "schedule")',
+        status: 'success'
+      }));
+      const workflowRunsSorted = workflowRuns.sort((a, b) => b.run_number - a.run_number);
+
+      return workflowRunsSorted[0].id
+```
+And now you can use the output of this step to call this action:
+```yaml
+- uses: XanaduAI/cloud-actions/download-github-workflow-artifact@main
+  with:
+    workflow_run_id: ${{ steps.workflow_run_id.outputs.result }}
+    github_token: ${{ github.token }}
+```

--- a/download-github-workflow-artifact/README.md
+++ b/download-github-workflow-artifact/README.md
@@ -1,0 +1,6 @@
+# Download GitHub Workflow Artifact
+
+This action allows the calling action to download workflow artifacts from other workflow. It should be noted that if you
+are attempting to download artifacts between different jobs within the same workflow, use [actions/download-artifact](https://github.com/actions/download-artifact).
+
+

--- a/download-github-workflow-artifact/action.yml
+++ b/download-github-workflow-artifact/action.yml
@@ -21,6 +21,10 @@ inputs:
     description: The maximum number of times a download will be retried if there is an error during the download process
     required: false
     default: '15'
+  github_token:
+    description: The GITHUB_TOKEN. Must have access to post comments on pull requests.
+    required: true
+
 
 runs:
   using: composite
@@ -28,7 +32,7 @@ runs:
     - shell: bash
       id: download_dir
       run: |
-        if [ "${{ inputs.artifact_download_dir }}" === '' ]
+        if [ '${{ inputs.artifact_download_dir }}' === '' ]
         then
           echo 'dir_name=${{ github.workspace }}' >> $GITHUB_OUTPUT
         else

--- a/download-github-workflow-artifact/action.yml
+++ b/download-github-workflow-artifact/action.yml
@@ -28,7 +28,7 @@ runs:
     - shell: bash
       id: download_dir
       run: |
-        if [ "${{ input.artifact_download_dir }}" === '' ]
+        if [ "${{ inputs.artifact_download_dir }}" === '' ]
         then
           echo 'dir_name=${{ github.workspace }}' >> $GITHUB_OUTPUT
         else

--- a/download-github-workflow-artifact/action.yml
+++ b/download-github-workflow-artifact/action.yml
@@ -1,0 +1,47 @@
+name: Download Artifact from GitHub Actions Workflow
+description: |
+  This action allows the calling action to download workflow artifacts from other workflow. 
+  Has a built-in retry mechanism with exponential backoff.
+
+inputs:
+  workflow_run_id:
+    description: The workflow run id from which to download the artifacts
+    required: true
+  artifact_name_regex:
+    description: |
+      A regex that can be used to match certain artifact names if all artifacts should not be downloaded
+    required: false
+    default: .*
+  artifact_download_dir:
+    description: |
+      The directory where all the artifacts need to be downloaded to. If not provided will default to GITHUB.WORKSPACE
+    required: false
+    default: ''
+  max_retry:
+    description: The maximum number of times a download will be retried if there is an error during the download process
+    required: false
+    default: '15'
+
+runs:
+  using: composite
+  steps:
+    - shell: bash
+      id: download_dir
+      run: |
+        if [ "${{ input.artifact_download_dir }}" === '' ]
+        then
+          echo 'dir_name=${{ github.workspace }}' >> $GITHUB_OUTPUT
+        else
+          echo 'dir_name=${{ inputs.artifact_download_dir }}' >> $GITHUB_OUTPUT
+        fi
+
+    - uses: actions/github-script@v6
+      with:
+        github-token: ${{ inputs.github_token }}
+        script: |
+          const script = require('${{ github.action_path }}/download.js');
+          await script({github, context}, 
+                      ${{ inputs.workflow_run_id }}, 
+                      "${{ inputs.artifact_name_regex }}", 
+                      "${{ steps.download_dir.outputs.dir_name }}",
+                      ${{ inputs.max_retry }});

--- a/download-github-workflow-artifact/action.yml
+++ b/download-github-workflow-artifact/action.yml
@@ -32,7 +32,7 @@ runs:
     - shell: bash
       id: download_dir
       run: |
-        if [ '${{ inputs.artifact_download_dir }}' === '' ]
+        if [ '${{ inputs.artifact_download_dir }}' == '' ]
         then
           echo 'dir_name=${{ github.workspace }}' >> $GITHUB_OUTPUT
         else

--- a/download-github-workflow-artifact/action.yml
+++ b/download-github-workflow-artifact/action.yml
@@ -29,16 +29,6 @@ inputs:
 runs:
   using: composite
   steps:
-#    - shell: bash
-#      id: download_dir
-#      run: |
-#        if [ '${{ inputs.artifact_download_dir }}' == '' ]
-#        then
-#          echo 'dir_name=${{ github.workspace }}' >> $GITHUB_OUTPUT
-#        else
-#          echo 'dir_name=${{ inputs.artifact_download_dir }}' >> $GITHUB_OUTPUT
-#        fi
-
     - uses: actions/github-script@v6
       with:
         github-token: ${{ inputs.github_token }}

--- a/download-github-workflow-artifact/action.yml
+++ b/download-github-workflow-artifact/action.yml
@@ -16,7 +16,7 @@ inputs:
     description: |
       The directory where all the artifacts need to be downloaded to. If not provided will default to GITHUB.WORKSPACE
     required: false
-    default: ''
+    default: '${{ github.workspace }}'
   max_retry:
     description: The maximum number of times a download will be retried if there is an error during the download process
     required: false
@@ -29,15 +29,15 @@ inputs:
 runs:
   using: composite
   steps:
-    - shell: bash
-      id: download_dir
-      run: |
-        if [ '${{ inputs.artifact_download_dir }}' == '' ]
-        then
-          echo 'dir_name=${{ github.workspace }}' >> $GITHUB_OUTPUT
-        else
-          echo 'dir_name=${{ inputs.artifact_download_dir }}' >> $GITHUB_OUTPUT
-        fi
+#    - shell: bash
+#      id: download_dir
+#      run: |
+#        if [ '${{ inputs.artifact_download_dir }}' == '' ]
+#        then
+#          echo 'dir_name=${{ github.workspace }}' >> $GITHUB_OUTPUT
+#        else
+#          echo 'dir_name=${{ inputs.artifact_download_dir }}' >> $GITHUB_OUTPUT
+#        fi
 
     - uses: actions/github-script@v6
       with:
@@ -47,5 +47,5 @@ runs:
           await script({github, context}, 
                       ${{ inputs.workflow_run_id }}, 
                       "${{ inputs.artifact_name_regex }}", 
-                      "${{ steps.download_dir.outputs.dir_name }}",
+                      "${{ inputs.artifact_download_dir }}",
                       ${{ inputs.max_retry }});

--- a/download-github-workflow-artifact/action.yml
+++ b/download-github-workflow-artifact/action.yml
@@ -18,7 +18,7 @@ inputs:
     required: false
     default: '${{ github.workspace }}'
   max_retry:
-    description: The maximum number of times a download will be retried if there is an error during the download process
+    description: The maximum number of times a download will be retried if there is an error during the download process. Default is 15
     required: false
     default: '15'
   github_token:

--- a/download-github-workflow-artifact/download.js
+++ b/download-github-workflow-artifact/download.js
@@ -10,7 +10,7 @@ module.exports = async ({github, context}, workflow_run_id, artifact_name_regex,
             artifact_id: artifact.id,
             archive_format: 'zip'
         });
-        fs.writeFileSync(`${artifact_download_dir}/${artifact.name}`, Buffer.from(download.data));
+        fs.writeFileSync(`${artifact_download_dir}/${artifact.name}.zip`, Buffer.from(download.data));
     };
 
     let artifactsAll = await github.rest.actions.listWorkflowRunArtifacts({

--- a/download-github-workflow-artifact/download.js
+++ b/download-github-workflow-artifact/download.js
@@ -1,6 +1,6 @@
 let fs = require('fs');
 
-module.exports = async ({github, context}, workflow_run_id, artifact_name_regex, artifact_download_dir, max_retry = 15) => {
+module.exports = async ({github, context}, workflow_run_id, artifact_name_regex, artifact_download_dir, max_retry) => {
     // Exponential backoff with a ceiling at 30 seconds
     const backoffDelay = (retryCount) => new Promise(resolve => setTimeout(resolve, 100 * Math.min(300, 1 << retryCount)));
 

--- a/download-github-workflow-artifact/download.js
+++ b/download-github-workflow-artifact/download.js
@@ -35,12 +35,12 @@ module.exports = async ({github, context}, workflow_run_id, artifact_name_regex,
     for (const artifact of artifactsFiltered) {
         for (let i = 1; i < max_retry + 1; i++) {
             try {
-                console.log(`Attempting to download artifact: ${artifact.name}`);
+                console.log(`Attempting to download artifact (${artifact.id}): ${artifact_download_dir}/${artifact.name}.zip`);
                 await downloadArtifact(artifact);
-                console.log(`Successfully downloaded artifact: ${artifact.name}`);
+                console.log(`Successfully downloaded artifact (${artifact.id}): ${artifact_download_dir}/${artifact.name}.zip`);
                 break;
             } catch (e) {
-                console.log(`Error while trying to download artifact: ${artifact.name}, i: ${i}, error: ${e}`);
+                console.log(`Error while trying to download artifact (${artifact.id}): ${artifact_download_dir}/${artifact.name}.zip, retryCount: ${i}, error: ${e}`);
                 ['message', 'status', 'request', 'response'].forEach((attr) => {
                     if (e.hasOwnProperty(attr)) {
                         console.log(`error_${attr}:`);

--- a/download-github-workflow-artifact/download.js
+++ b/download-github-workflow-artifact/download.js
@@ -34,13 +34,14 @@ module.exports = async ({github, context}, workflow_run_id, artifact_name_regex,
     */
     for (const artifact of artifactsFiltered) {
         for (let i = 1; i < max_retry + 1; i++) {
+            const artifactFullName = `${artifact_download_dir}/${artifact.name}.zip`;
             try {
-                console.log(`Attempting to download artifact (${artifact.id}): ${artifact_download_dir}/${artifact.name}.zip`);
+                console.log(`Attempting to download artifact (${artifact.id}): ${artifactFullName}`);
                 await downloadArtifact(artifact);
-                console.log(`Successfully downloaded artifact (${artifact.id}): ${artifact_download_dir}/${artifact.name}.zip`);
+                console.log(`Successfully downloaded artifact (${artifact.id}): ${artifactFullName}`);
                 break;
             } catch (e) {
-                console.log(`Error while trying to download artifact (${artifact.id}): ${artifact_download_dir}/${artifact.name}.zip, retryCount: ${i}, error: ${e}`);
+                console.log(`Error while trying to download artifact (${artifact.id}): ${artifactFullName}, retryCount: ${i}, error: ${e}`);
                 ['message', 'status', 'request', 'response'].forEach((attr) => {
                     if (e.hasOwnProperty(attr)) {
                         console.log(`error_${attr}:`);
@@ -48,7 +49,7 @@ module.exports = async ({github, context}, workflow_run_id, artifact_name_regex,
                     }
                 });
                 if (i === max_retry) throw new Error(e);
-                console.log(`Retrying download of artifact: ${artifact.name}`);
+                console.log(`Retrying download of artifact (${artifact.id}): ${artifactFullName}`);
                 await backoffDelay(i);
             }
         }

--- a/download-github-workflow-artifact/download.js
+++ b/download-github-workflow-artifact/download.js
@@ -1,7 +1,8 @@
 let fs = require('fs');
 
 module.exports = async ({github, context}, workflow_run_id, artifact_name_regex, artifact_download_dir, max_retry = 15) => {
-    const backoffDelay = (retryCount) => new Promise(resolve => setTimeout(resolve, 1000 * retryCount));
+    // Exponential backoff with a ceiling at 30 seconds
+    const backoffDelay = (retryCount) => new Promise(resolve => setTimeout(resolve, 100 * Math.min(300, 1 << retryCount)));
 
     const downloadArtifact = async (artifact) => {
         let download = await github.rest.actions.downloadArtifact({

--- a/download-github-workflow-artifact/download.js
+++ b/download-github-workflow-artifact/download.js
@@ -1,0 +1,56 @@
+let fs = require('fs');
+
+module.exports = async ({github, context}, workflow_run_id, artifact_name_regex, artifact_download_dir, max_retry = 15) => {
+    const backoffDelay = (retryCount) => new Promise(resolve => setTimeout(resolve, 1000 * retryCount));
+
+    const downloadArtifact = async (artifact) => {
+        let download = await github.rest.actions.downloadArtifact({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            artifact_id: artifact.id,
+            archive_format: 'zip'
+        });
+        fs.writeFileSync(`${artifact_download_dir}/${artifact.name}`, Buffer.from(download.data));
+    };
+
+    let artifactsAll = await github.rest.actions.listWorkflowRunArtifacts({
+        owner: context.repo.owner,
+        repo: context.repo.repo,
+        run_id: workflow_run_id
+    });
+    let artifactsFiltered = artifactsAll.data.artifacts.filter((artifact) => {
+        return artifact.name.match(artifact_name_regex)
+    });
+
+    /*
+      Attempt to download the artifact one at a time and save them to disk.
+      In the event of an error, back-off (incrementally) and try again.
+
+      Each error increases the back-off delay by 1s, in other words:
+      > failure -> wait (1s) -> try-again -> failure -> wait (2s) -> try-again -> ...
+
+      This deals with network congestion and rate-limiting errors that occur if the artifact
+      download happens during a time of high load on GitHub Actions.
+    */
+    for (const artifact of artifactsFiltered) {
+        for (let i = 1; i < max_retry + 1; i++) {
+            try {
+                console.log(`Attempting to download artifact: ${artifact.name}`);
+                await downloadArtifact(artifact);
+                console.log(`Successfully downloaded artifact: ${artifact.name}`);
+                break;
+            } catch (e) {
+                console.log(`Error while trying to download artifact: ${artifact.name}, i: ${i}, error: ${e}`);
+                ['message', 'status', 'request', 'response'].forEach((attr) => {
+                    if (e.hasOwnProperty(attr)) {
+                        console.log(`error_${attr}:`);
+                        console.log(e[attr]);
+                    }
+                });
+                if (i === max_retry) throw new Error(e);
+                console.log(`Retrying download of artifact: ${artifact.name}`);
+                await backoffDelay(i);
+            }
+        }
+    }
+}


### PR DESCRIPTION
**Summary**
This PR adds a new action that allows an action to download an artifact from other workflows. Do note this is not an action you would use to download artifacts between jobs within the same workflow, you would use `actions/download-artifact` for that. However, in the scenarios (as outlined in the README of the action), there are scenarios where you would need to download an artifact from an external workflow.

The downloading of the external workflow has a lot of network hiccups, and this action implements linear back-off and retry mechanism to handle that.