### PR TITLE
Avoid usage of `::set-output`

### DIFF
--- a/build-docker-image/action.yml
+++ b/build-docker-image/action.yml
@@ -23,8 +23,8 @@ runs:
         DOCKER_BUILDKIT: 1
       run: >
         docker build
-          --ssh default
-          --tag ${{ inputs.tag }}
-          --target ${{ inputs.target }}
-          --build-arg COMMIT_SHA=${{ github.sha }}
-          ${{ inputs.docker-build-extra-args }} ${{ inputs.path }}
+        --ssh default
+        --tag ${{ inputs.tag }}
+        --target ${{ inputs.target }}
+        --build-arg COMMIT_SHA=${{ github.sha }}
+        ${{ inputs.docker-build-extra-args }} ${{ inputs.path }}

--- a/build-docker-image/action.yml
+++ b/build-docker-image/action.yml
@@ -1,55 +1,31 @@
 name: Build Docker Image
-description: Build a local Docker image using buildkit
+description: Builds a Docker image (with BuildKit enabled).
 
 inputs:
   path:
-    description: Path to Docker build context
+    description: Docker build context path (e.g., ".").
     required: true
   target:
-    description: Docker build target
+    description: Docker build target (e.g., "server").
     required: true
   tag:
-    description: Local tag for Docker image
+    description: Docker build image tag (e.g., "server-production").
+    required: true
+  docker-build-extra-args:
+    description: Docker build extra arguments (e.g., "--build-arg DEBUG=false").
     required: false
-  docker-args:
-    description: Extra arguments to docker build
-    required: false
-
-outputs:
-  image-id:
-    description: Docker image ID
-    value: ${{ steps.get-image-id.outputs.id }}
 
 runs:
   using: composite
   steps:
-    - name: Generate ID file path
-      id: id-file
-      shell: bash
-      run: printf "::set-output name=path::%s/iidfile_%s_$RANDOM" ${{ runner.temp }} $(date +%s)
-
-    - name: Build image
-      shell: bash
+    - shell: bash
       env:
         DOCKER_BUILDKIT: 1
-      run: |
+      run:
         docker build \
-          --iidfile=${{ steps.id-file.outputs.path }} \
-          --target=${{ inputs.target }} \
-          --build-arg COMMIT_SHA=$(git rev-parse --short HEAD) \
-          ${{ inputs.docker-args }} ${{ inputs.path }}
-
-    - name: Get image ID
-      id: get-image-id
-      shell: bash
-      run: |
-        printf "::set-output name=id::%s" $(cat ${{ steps.id-file.outputs.path }})
-        rm -f ${{ steps.id-file.outputs.path }}
-
-    - name: Tag image
-      shell: bash
-      run: |
-        if [ -n "${{ inputs.tag }}" ]
-        then
-          docker tag ${{ steps.get-image-id.outputs.id }} ${{ inputs.tag }}
-        fi
+          --ssh default \
+          --tag ${{ inputs.tag }} \
+          --target ${{ inputs.target }} \
+          --build-arg COMMIT_SHA=${{ github.sha }} \
+          ${{ inputs.docker-build-extra-args }} \
+          ${{ inputs.path }}

--- a/build-docker-image/action.yml
+++ b/build-docker-image/action.yml
@@ -21,10 +21,11 @@ runs:
     - shell: bash
       env:
         DOCKER_BUILDKIT: 1
-      run:
-        docker build \
-          --ssh default \
-          --tag ${{ inputs.tag }} \
-          --target ${{ inputs.target }} \
-          --build-arg COMMIT_SHA=${{ github.sha }} \
-          ${{ inputs.docker-build-extra-args }} ${{ inputs.path }}
+      run: >
+        docker build
+          --ssh default
+          --tag ${{ inputs.tag }}
+          --target ${{ inputs.target }}
+          --build-arg COMMIT_SHA=${{ github.sha }}
+          ${{ inputs.docker-build-extra-args }}
+          ${{ inputs.path }}

--- a/build-docker-image/action.yml
+++ b/build-docker-image/action.yml
@@ -27,5 +27,4 @@ runs:
           --tag ${{ inputs.tag }}
           --target ${{ inputs.target }}
           --build-arg COMMIT_SHA=${{ github.sha }}
-          ${{ inputs.docker-build-extra-args }}
-          ${{ inputs.path }}
+          ${{ inputs.docker-build-extra-args }} ${{ inputs.path }}

--- a/build-docker-image/action.yml
+++ b/build-docker-image/action.yml
@@ -27,5 +27,4 @@ runs:
           --tag ${{ inputs.tag }} \
           --target ${{ inputs.target }} \
           --build-arg COMMIT_SHA=${{ github.sha }} \
-          ${{ inputs.docker-build-extra-args }} \
-          ${{ inputs.path }}
+          ${{ inputs.docker-build-extra-args }} ${{ inputs.path }}

--- a/build-docker-images/action.yml
+++ b/build-docker-images/action.yml
@@ -11,7 +11,7 @@ inputs:
     description: Docker build targets as a space-separated list (e.g., "daemon server").
     required: true
   docker-build-extra-args:
-    description: Docker build extra arguments.
+    description: Docker build extra arguments (e.g., "--build-arg DEBUG=false").
     required: false
 
 runs:

--- a/generate-docker-image-tags/action.yml
+++ b/generate-docker-image-tags/action.yml
@@ -45,7 +45,7 @@ runs:
           printf 'Cannot determine tags: Workflow must be triggered by "push", "pull_request", or "release" event.' && exit 1
         fi
 
-        printf "::set-output name=branch::$BRANCH"
+        echo "branch=$BRANCH" >> $GITHUB_OUTPUT
 
     - id: get-tags
       shell: bash
@@ -95,4 +95,4 @@ runs:
           done <<< "$ids"
         fi
 
-        printf "::set-output name=tags::$TAGS"
+        echo "tags=$TAGS" >> $GITHUB_OUTPUT


### PR DESCRIPTION
**Stories:**

* https://app.shortcut.com/xanaduai/story/29068/avoid-using-set-output-in-cloud-actions

**Changes:**

* Simplified the Build Docker Image Action to just one step.
* Made the `tag` input of the Build Docker Image Action mandatory (building an unused image is questionable).
* Replaced `::set-output` by appending to `$GITHUB_OUTPUT` in the GDIT Action as per [this GitHub article](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/#examples).

**Tests:**
* https://github.com/XanaduAI/grader-service/pull/348.
* https://github.com/XanaduAI/minordomo/pull/90
* https://github.com/XanaduAI/platform-backing-services/pull/57