### PR TITLE
Replace slashes with hyphens

### DIFF
--- a/generate-docker-image-tags/action.yml
+++ b/generate-docker-image-tags/action.yml
@@ -57,9 +57,8 @@ runs:
         then
           TAGS="latest,$BRANCH,$COMMIT_SHA"
         else
-          BADCHAR="/"
-          GOODCHAR="-"
-          TAGS="${{ inputs.prefix }}.${BRANCH//$BADCHAR/$GOODCHAR},${{ inputs.prefix }}.$COMMIT_SHA"
+          SLASHLESS_BRANCH=`echo $BRANCH | tr / -`
+          TAGS="${{ inputs.prefix }}.$SLASHLESS_BRANCH,${{ inputs.prefix }}.$COMMIT_SHA"
         fi
 
         if [ "$GITHUB_EVENT_NAME" == "pull_request" ]

--- a/generate-docker-image-tags/action.yml
+++ b/generate-docker-image-tags/action.yml
@@ -57,7 +57,9 @@ runs:
         then
           TAGS="latest,$BRANCH,$COMMIT_SHA"
         else
-          TAGS="${{ inputs.prefix }}.$BRANCH,${{ inputs.prefix }}.$COMMIT_SHA"
+          BADCHAR="/"
+          GOODCHAR="-"
+          TAGS="${{ inputs.prefix }}.${BRANCH//$BADCHAR/$GOODCHAR},${{ inputs.prefix }}.$COMMIT_SHA"
         fi
 
         if [ "$GITHUB_EVENT_NAME" == "pull_request" ]


### PR DESCRIPTION
Handling slashes in branch names by replacing them with hyphens when generating tags for Docker images.

Example output tags after running the new version of the `generate-docker-image-tags` action on the branch `sc-28060/testing/slashes/in/branches` (see PR #29):

![image](https://user-images.githubusercontent.com/50180049/216657631-ea1efe24-48fd-4e34-92eb-e8298096f011.png)
