### PR TITLE
Allow custom pip command in og unit

### DIFF
--- a/og/unit/action.yml
+++ b/og/unit/action.yml
@@ -23,7 +23,7 @@ runs:
     - run: | 
         eval `ssh-agent`
         echo "${{ inputs.key }}" | ssh-add -
-        `${{ inputs.pip_command }}`
+        ${{ inputs.pip_command }}
         pip install pytest pytest-cov 
       shell: bash
 

--- a/og/unit/action.yml
+++ b/og/unit/action.yml
@@ -12,6 +12,10 @@ inputs:
     description: The path for unit tests
     required: false
     default: '.'
+  pip_command:
+    descrption: Custom pip install command
+    required: false
+    default: 'pip install -r ./requirements.txt'
 
 runs:
   using: "composite"
@@ -19,7 +23,7 @@ runs:
     - run: | 
         eval `ssh-agent`
         echo "${{ inputs.key }}" | ssh-add -
-        pip install -r ./requirements.txt
+        `${{ inputs.pip_command }}`
         pip install pytest pytest-cov 
       shell: bash
 


### PR DESCRIPTION
Allow users to run custom pip install scripts. This is especially useful for adding verbosity flags, etc.