### PR TITLE
Adds a newline at the end of version.py

### DIFF
--- a/og/bump/tagger.py
+++ b/og/bump/tagger.py
@@ -101,7 +101,7 @@ def bump() -> str:
         logger.info(f"Calling {bump_ver} using PR title")
 
     logger.info(f"Tagging new version: {new_ver}")
-    ver_file.write_text(f'__version__ = "{leading_v}{new_ver}"')
+    ver_file.write_text(f'__version__ = "{leading_v}{new_ver}"\n')
 
     return f"{leading_v}{new_ver}"
 


### PR DESCRIPTION
The workflow in most repos would run formatter/linters after the fact masking the missing newline.