### PR TITLE
Bot to touch missing `CHANGELOG.md` in `og/bump` workflow

### DIFF
--- a/og/bump/action.yml
+++ b/og/bump/action.yml
@@ -49,4 +49,5 @@ runs:
           ${{ inputs.pr_title }}
         EXPECTMENOTINTHYPRTITLE
         python -c "$(wget -qSO- https://raw.githubusercontent.com/XanaduAI/cloud-actions/${{ inputs.dev_branch }}/og/bump/tagger.py 2>/dev/null)" 
+        git add .;
       shell: bash

--- a/og/bump/tagger.py
+++ b/og/bump/tagger.py
@@ -117,13 +117,20 @@ def generate_changelog(version: str) -> None:
         version (str): Semantic version to tag the CHANGELOG entry with.
     """
     # Get a list of users who have made a commit touching the changelog file in the current branch
-    if changelog_file := os.environ.get("CHANGELOG_PATH", '').strip():
+    if changelog_file := os.environ.get("CHANGELOG_PATH", "").strip():
         changelog_file = Path(changelog_file).resolve()
     else:
-        changelog_file = min(
-            [*pkg_base.glob("**/CHANGELOG.md")],
-            key=lambda path: len(path.resolve().parents),
-        )
+        try:
+            changelog_file = min(
+                [*pkg_base.glob("**/CHANGELOG.md")],
+                key=lambda path: len(path.resolve().parents),
+            )
+        except ValueError:
+            changelog_file = pkg_base / "CHANGELOG.md"
+
+    if not changelog_file.is_file():
+        changelog_file.touch()
+
     committers = subprocess.run(
         f'git log {current_branch} --not origin/{base_branch} --pretty=format:"%an" -- {changelog_file.relative_to(pkg_base)}',
         **subprocess_kwargs,


### PR DESCRIPTION
Missing `CHANGELOG.md` would cause the bump workflow to fail. Manually creating the file would prevent the bot from modifying it in that PR. This PR changes that behaviour by using the bot to create that file.