### PR TITLE
fix: [sc-40595] Sanity check for `_version.py` vs head of `CHANGELOG.md`

### DIFF
--- a/og/bump/tagger.py
+++ b/og/bump/tagger.py
@@ -141,7 +141,7 @@ def generate_changelog(version: str) -> None:
 
     if any(non_bot_committers):
         logger.info("Non BOT commit detected, will not modify CHANGELOG.")
-        line = [*filter(None, changelog_file.read_text().splitlines())][0]
+        line = next(filter(lambda line: not line.isspace() and bool(line), changelog_file.read_text().splitlines()))
         if not line.removeprefix("# ") == version:
             raise RuntimeError(f"Unexpected version in CHANGELOG. Expected {version}, got {line}.")
                     

--- a/og/bump/tagger.py
+++ b/og/bump/tagger.py
@@ -141,10 +141,17 @@ def generate_changelog(version: str) -> None:
 
     if any(non_bot_committers):
         logger.info("Non BOT commit detected, will not modify CHANGELOG.")
-        line = next(filter(lambda line: not line.isspace() and bool(line), changelog_file.read_text().splitlines()))
+        line = next(
+            filter(
+                lambda line: not line.isspace() and bool(line),
+                changelog_file.read_text().splitlines(),
+            )
+        )
         if not line.removeprefix("# ") == version:
-            raise RuntimeError(f"Unexpected version in CHANGELOG. Expected {version}, got {line}.")
-                    
+            raise RuntimeError(
+                f"Unexpected version in CHANGELOG. Expected {version}, got {line}."
+            )
+
         return None
 
     base_changelog = subprocess.run(

--- a/og/bump/tagger.py
+++ b/og/bump/tagger.py
@@ -141,11 +141,9 @@ def generate_changelog(version: str) -> None:
 
     if any(non_bot_committers):
         logger.info("Non BOT commit detected, will not modify CHANGELOG.")
-        with changelog_file.open('r') as fd:
-            while not(line:=''):
-                line=fd.readline().strip()
-            if not line.removeprefix("# ") == version:
-                raise RuntimeError(f"Unexpected version in CHANGELOG. Expected {version}, got {line}.")
+        line = [*filter(None, changelog_file.read_text().splitlines())][0]
+        if not line.removeprefix("# ") == version:
+            raise RuntimeError(f"Unexpected version in CHANGELOG. Expected {version}, got {line}.")
                     
         return None
 

--- a/og/bump/tagger.py
+++ b/og/bump/tagger.py
@@ -142,9 +142,10 @@ def generate_changelog(version: str) -> None:
     if any(non_bot_committers):
         logger.info("Non BOT commit detected, will not modify CHANGELOG.")
         with changelog_file.open('r') as fd:
-            while not(line:=fd.readline().strip()):
-                if not line.removeprefix("# ") == version:
-                    raise RuntimeError(f"Unexpected version in CHANGELOG. Expected {version}, got {line}.")
+            while not(line:=''):
+                line=fd.readline().strip()
+            if not line.removeprefix("# ") == version:
+                raise RuntimeError(f"Unexpected version in CHANGELOG. Expected {version}, got {line}.")
                     
         return None
 

--- a/og/bump/tagger.py
+++ b/og/bump/tagger.py
@@ -147,9 +147,9 @@ def generate_changelog(version: str) -> None:
                 changelog_file.read_text().splitlines(),
             )
         )
-        if not line.removeprefix("# ") == version:
+        if not (changelog_version := line.removeprefix("# ")) == version:
             raise RuntimeError(
-                f"Unexpected version in CHANGELOG. Expected {version}, got {line}."
+                f"Unexpected version in CHANGELOG. Expected {version}, got {changelog_version}."
             )
 
         return None

--- a/og/bump/tagger.py
+++ b/og/bump/tagger.py
@@ -141,6 +141,11 @@ def generate_changelog(version: str) -> None:
 
     if any(non_bot_committers):
         logger.info("Non BOT commit detected, will not modify CHANGELOG.")
+        with changelog_file.open('r') as fd:
+            while not(line:=fd.readline().strip()):
+                if not line.removeprefix("# ") == version:
+                    raise RuntimeError(f"Unexpected version in CHANGELOG. Expected {version}, got {line}.")
+                    
         return None
 
     base_changelog = subprocess.run(


### PR DESCRIPTION
adds a sanity check that will complain if the CHANGELOG.md HEAD is not the same as the version specified in _version.py