### PR TITLE
Consider CHANGELOG diff when deciding to modify

### DIFF
--- a/og/bump/tagger.py
+++ b/og/bump/tagger.py
@@ -139,7 +139,13 @@ def generate_changelog(version: str) -> None:
     # Filter the committer list by who has "bot" in their name as a separate word
     non_bot_committers = filter(lambda x: "bot" not in x.lower().split(" "), committers)
 
-    if any(non_bot_committers):
+    # Check if the changelog file is identical to the base_branch changelog
+    changelog_was_modified = bool(subprocess.run(
+        f'git diff origin/{base_branch} -s --exit-code -- {changelog_file.relative_to(pkg_base)}',
+        **subprocess_kwargs
+    ).returncode)
+
+    if any(non_bot_committers) and changelog_was_modified:
         logger.info("Non BOT commit detected, will not modify CHANGELOG.")
         line = next(
             filter(

--- a/og/bump/tagger.py
+++ b/og/bump/tagger.py
@@ -139,9 +139,9 @@ def generate_changelog(version: str) -> None:
     # Filter the committer list by who has "bot" in their name as a separate word
     non_bot_committers = filter(lambda x: "bot" not in x.lower().split(" "), committers)
 
-    # Check if the changelog file is identical to the base_branch changelog
+    # Check if the changelog file is identical (ignoring whitespace) to the base_branch changelog
     changelog_was_modified = bool(subprocess.run(
-        f'git diff origin/{base_branch} -s --exit-code -- {changelog_file.relative_to(pkg_base)}',
+        f'git diff origin/{base_branch} --ignore-blank-lines -w -s --exit-code -- {changelog_file.relative_to(pkg_base)}',
         **subprocess_kwargs
     ).returncode)
 


### PR DESCRIPTION
Updates the og/bump action to consider the changelog diff between branch and base_branch when deciding whether or not to modify the changelog. If there is no change (as determined by `git diff`) the bot will prepend a new entry to the changelog, ignoring the presence of non-bot commits to the file.

Previously, if any commits touching the CHANGELOG file with "non-bot" authors were found, the bot would not attempt to prepend a change entry to the log (to avoid clobbering manual modifications). In cases where the changelog had manually resolved conflicts or revert commits, this behavior was frequently undesired. The new logic makes it easier to "reset" the state of the _version and/or CHANGELOG files and have the bot automatically re-apply desired changes.

These changes were tested and the results can be seen here: https://github.com/XanaduAI/gittagtest/pull/20