### PR TITLE
Allow creation of `.lintignore` file to ignore linting of files and directories

### DIFF
--- a/og/lint/action.yml
+++ b/og/lint/action.yml
@@ -15,15 +15,6 @@ runs:
       shell: bash
 
     - run: |
-          MODIFIED_PY_FILES="$(git diff origin/${{ inputs.base_branch }} --diff-filter=MAC --name-only | (grep -i '\.py$' || true) | xargs -r realpath)"
-          if [ -n "${MODIFIED_PY_FILES}" ]; then \
-            echo "Running black..." ; \
-            black ${MODIFIED_PY_FILES} ; \
-            echo "Running isort..." ; \
-            isort --profile=black ${MODIFIED_PY_FILES} ; \
-            echo "Running docformatter..." ; \
-            trap 'docformatter --recursive --in-place --wrap-summaries 88 --wrap-descriptions 88 ${MODIFIED_PY_FILES} || echo "docformatter returned status 3."' EXIT; \
-            echo "Running flake8..." ; \
-            flake8 --ignore=E203,E501,W503 ${MODIFIED_PY_FILES} ; \
-          fi
+          export BASE_BRANCH=${{ inputs.base_branch }}
+          python resolve.py
       shell: bash

--- a/og/lint/resolve.py
+++ b/og/lint/resolve.py
@@ -4,24 +4,29 @@ from pathlib import Path
 
 ignore_files = set()
 
-if (ignore_file := Path("./.lintignore")).isfile():
+if (ignore_file := Path("./.lintignore")).is_file():
     ignore_paths = ignore_file.read_text().split()
     for path in ignore_paths:
-        ignore_files.update(path.rglob("*"))
+        path = Path(path)
+        if path.is_dir():
+            ignore_files.update(map(Path.resolve, path.rglob("*")))
+        else:
+            ignore_files.update([path.resolve()])
 
 edited_py_files = {
     _file
-    for file in subprocess(
+    for file in subprocess.run(
         f"git diff origin/{os.environ['BASE_BRANCH']} --diff-filter=MAC --name-only",
         shell=True,
         stdout=subprocess.PIPE,
+        encoding="utf-8",
     ).stdout.split()
     if (_file := Path(file).resolve()).suffix == ".py"
 }
 
 files_to_format = edited_py_files - ignore_files
 
-if files_to_format := " ".join(files_to_format):
+if files_to_format := " ".join(map(str, files_to_format)):
     print("Running black...")
     subprocess.run(f"black {files_to_format}", shell=True)
     print("Running isort...")
@@ -31,7 +36,7 @@ if files_to_format := " ".join(files_to_format):
         subprocess.run(
             f"docformatter --recursive --in-place --wrap-summaries 88 --wrap-descriptions 88 {files_to_format}",
             shell=True,
-        ).rc
+        ).returncode
         == 3
     ):
         print("Docformatter raised status 3")

--- a/og/lint/resolve.py
+++ b/og/lint/resolve.py
@@ -1,0 +1,41 @@
+import os
+import subprocess
+from pathlib import Path
+
+ignore_files = set()
+
+if (ignore_file := Path("./.lintignore")).isfile():
+    ignore_paths = ignore_file.read_text().split()
+    for path in ignore_paths:
+        ignore_files.update(path.rglob("*"))
+
+edited_py_files = {
+    _file
+    for file in subprocess(
+        f"git diff origin/{os.environ['BASE_BRANCH']} --diff-filter=MAC --name-only",
+        shell=True,
+        stdout=subprocess.PIPE,
+    ).stdout.split()
+    if (_file := Path(file).resolve()).suffix == ".py"
+}
+
+files_to_format = edited_py_files - ignore_files
+
+if files_to_format := " ".join(files_to_format):
+    print("Running black...")
+    subprocess.run(f"black {files_to_format}", shell=True)
+    print("Running isort...")
+    subprocess.run(f"isort --profile=black {files_to_format}", shell=True)
+    print("Running docformatter")
+    if (
+        subprocess.run(
+            f"docformatter --recursive --in-place --wrap-summaries 88 --wrap-descriptions 88 {files_to_format}",
+            shell=True,
+        ).rc
+        == 3
+    ):
+        print("Docformatter raised status 3")
+    print("Running flake8")
+    subprocess.run(
+        f"flake8 --ignore=E203,E501,W503 {files_to_format}", shell=True, check=True
+    )


### PR DESCRIPTION
A `.lintignore` file at the top level allows users to specify files or entire directories to be excluded from linting/formatting

**NOTE**: Only works with paths relative to the base of the repo and does not resolve wildcards