### PR TITLE
Fixes a tiny bug where non-bot commits would return the old format of version for the CHANGELOG bump

### DIFF
--- a/og/bump/action.yml
+++ b/og/bump/action.yml
@@ -105,7 +105,7 @@ runs:
               logger.warn(
                 "Detected non bot commits to the version file, skipping version bump."
               )
-              return f"{leading_v}{file_ver}"
+              return str(file_ver)
 
           logger.info(f"{file_ver=} {base_branch_ver=}")
 


### PR DESCRIPTION
As of #50 we use `SemVer` to sort versions instead of string sorting. `SemVer` does not like leading `v` which forced us to make some changes in the `version` function as well. An early return was still using `leading_v` that caused changelog to fail. 