### PR TITLE
Allow providing custom owner and repo for download artifact action

### DIFF
--- a/download-github-workflow-artifact/README.md
+++ b/download-github-workflow-artifact/README.md
@@ -58,7 +58,8 @@ The following code snippet get the most recent successful build of a workflow, t
       return workflowRunsSorted[0].id
 ```
 And now you can use the output of this step to call this action. If the artifact is from another repository,
-the `owner` and `repo` parameters must be set:
+the `owner` and `repo` parameters must be set to point to the repository from which
+to download the artifact:
 ```yaml
 - uses: XanaduAI/cloud-actions/download-github-workflow-artifact@main
   with:

--- a/download-github-workflow-artifact/README.md
+++ b/download-github-workflow-artifact/README.md
@@ -58,7 +58,7 @@ The following code snippet get the most recent successful build of a workflow, t
       return workflowRunsSorted[0].id
 ```
 And now you can use the output of this step to call this action. If the artifact is from another repository,
-the `owner` and `repo` parameters must be set to point to the repository from which
+the `repository_owner` and `repository_name` parameters must be set to point to the repository from which
 to download the artifact:
 ```yaml
 - id: repo_information

--- a/download-github-workflow-artifact/README.md
+++ b/download-github-workflow-artifact/README.md
@@ -61,10 +61,15 @@ And now you can use the output of this step to call this action. If the artifact
 the `owner` and `repo` parameters must be set to point to the repository from which
 to download the artifact:
 ```yaml
+- id: repo_information
+  run: |
+    echo "owner=${{ github.repository_owner }}" >> $GITHUB_OUTPUT
+    echo "name=$(basename ${{ github.repository }})" >> $GITHUB_OUTPUT
+   
 - uses: XanaduAI/cloud-actions/download-github-workflow-artifact@main
   with:
-    owner: context.repo.owner
-    repo: context.repo.repo
+    owner: ${{ steps.repo_information.outputs.owner }}
+    repo: ${{ steps.repo_information.outputs.name }}
     workflow_run_id: ${{ steps.workflow_run_id.outputs.result }}
     github_token: ${{ github.token }}
 ```

--- a/download-github-workflow-artifact/README.md
+++ b/download-github-workflow-artifact/README.md
@@ -57,10 +57,13 @@ The following code snippet get the most recent successful build of a workflow, t
 
       return workflowRunsSorted[0].id
 ```
-And now you can use the output of this step to call this action:
+And now you can use the output of this step to call this action. If the artifact is from another repository,
+the `owner` and `repo` parameters must be set:
 ```yaml
 - uses: XanaduAI/cloud-actions/download-github-workflow-artifact@main
   with:
+    owner: context.repo.owner
+    repo: context.repo.repo
     workflow_run_id: ${{ steps.workflow_run_id.outputs.result }}
     github_token: ${{ github.token }}
 ```

--- a/download-github-workflow-artifact/README.md
+++ b/download-github-workflow-artifact/README.md
@@ -68,8 +68,8 @@ to download the artifact:
    
 - uses: XanaduAI/cloud-actions/download-github-workflow-artifact@main
   with:
-    owner: ${{ steps.repo_information.outputs.owner }}
-    repo: ${{ steps.repo_information.outputs.name }}
+    repository_owner: ${{ steps.repo_information.outputs.owner }}
+    repository_name: ${{ steps.repo_information.outputs.name }}
     workflow_run_id: ${{ steps.workflow_run_id.outputs.result }}
     github_token: ${{ github.token }}
 ```

--- a/download-github-workflow-artifact/action.yml
+++ b/download-github-workflow-artifact/action.yml
@@ -4,6 +4,14 @@ description: |
   Has a built-in retry mechanism with exponential backoff.
 
 inputs:
+  owner:
+    description: The owner of the repository containing the workflow
+    required: false
+    default: context.repo.owner
+  repo:
+    description: The name of the repository containing the workflow without the .git extension
+    required: false
+    default: context.repo.repo
   workflow_run_id:
     description: The workflow run id from which to download the artifacts
     required: true
@@ -34,7 +42,9 @@ runs:
         github-token: ${{ inputs.github_token }}
         script: |
           const script = require('${{ github.action_path }}/download.js');
-          await script({github, context}, 
+          await script({github}, 
+                      ${{ inputs.owner }}, 
+                      ${{ inputs.repo }}, 
                       ${{ inputs.workflow_run_id }}, 
                       "${{ inputs.artifact_name_regex }}", 
                       "${{ inputs.artifact_download_dir }}",

--- a/download-github-workflow-artifact/action.yml
+++ b/download-github-workflow-artifact/action.yml
@@ -7,11 +7,11 @@ inputs:
   owner:
     description: The owner of the repository containing the workflow
     required: false
-    default: context.repo.owner
+    default: ''
   repo:
     description: The name of the repository containing the workflow without the .git extension
     required: false
-    default: context.repo.repo
+    default: ''
   workflow_run_id:
     description: The workflow run id from which to download the artifacts
     required: true
@@ -41,10 +41,12 @@ runs:
       with:
         github-token: ${{ inputs.github_token }}
         script: |
+          const repoOwner = "${{ inputs.owner }}" || context.repo.owner;
+          const repoName = "${{ inputs.repo }}" || context.repo.repo;
           const script = require('${{ github.action_path }}/download.js');
           await script({github}, 
-                      ${{ inputs.owner }}, 
-                      ${{ inputs.repo }}, 
+                      repoOwner, 
+                      repoName, 
                       ${{ inputs.workflow_run_id }}, 
                       "${{ inputs.artifact_name_regex }}", 
                       "${{ inputs.artifact_download_dir }}",

--- a/download-github-workflow-artifact/action.yml
+++ b/download-github-workflow-artifact/action.yml
@@ -4,11 +4,11 @@ description: |
   Has a built-in retry mechanism with exponential backoff.
 
 inputs:
-  owner:
+  repository_owner:
     description: The owner of the repository containing the workflow
     required: false
     default: ''
-  repo:
+  repository_name:
     description: The name of the repository containing the workflow without the .git extension
     required: false
     default: ''
@@ -41,8 +41,8 @@ runs:
       with:
         github-token: ${{ inputs.github_token }}
         script: |
-          const repoOwner = "${{ inputs.owner }}" || context.repo.owner;
-          const repoName = "${{ inputs.repo }}" || context.repo.repo;
+          const repoOwner = "${{ inputs.repository_owner }}" || context.repo.owner;
+          const repoName = "${{ inputs.repository_name }}" || context.repo.repo;
           const script = require('${{ github.action_path }}/download.js');
           await script({github}, 
                       repoOwner, 

--- a/download-github-workflow-artifact/download.js
+++ b/download-github-workflow-artifact/download.js
@@ -1,13 +1,13 @@
 let fs = require('fs');
 
-module.exports = async ({github}, owner, repo, workflow_run_id, artifact_name_regex, artifact_download_dir, max_retry) => {
+module.exports = async ({github}, repository_owner, repository_name, workflow_run_id, artifact_name_regex, artifact_download_dir, max_retry) => {
     // Exponential backoff with a ceiling at 30 seconds
     const backoffDelay = (retryCount) => new Promise(resolve => setTimeout(resolve, 100 * Math.min(300, 1 << retryCount)));
 
     const downloadArtifact = async (artifact) => {
         let download = await github.rest.actions.downloadArtifact({
-            owner: owner,
-            repo: repo,
+            owner: repository_owner,
+            repo: repository_name,
             artifact_id: artifact.id,
             archive_format: 'zip'
         });
@@ -15,8 +15,8 @@ module.exports = async ({github}, owner, repo, workflow_run_id, artifact_name_re
     };
 
     let artifactsAllOpts = github.rest.actions.listWorkflowRunArtifacts.endpoint.merge({
-        owner: owner,
-        repo: repo,
+        owner: repository_owner,
+        repo: repository_name,
         run_id: workflow_run_id
     });
     let artifactsAll = await github.paginate(artifactsAllOpts);

--- a/download-github-workflow-artifact/download.js
+++ b/download-github-workflow-artifact/download.js
@@ -1,13 +1,13 @@
 let fs = require('fs');
 
-module.exports = async ({github, context}, workflow_run_id, artifact_name_regex, artifact_download_dir, max_retry) => {
+module.exports = async ({github}, owner, repo, workflow_run_id, artifact_name_regex, artifact_download_dir, max_retry) => {
     // Exponential backoff with a ceiling at 30 seconds
     const backoffDelay = (retryCount) => new Promise(resolve => setTimeout(resolve, 100 * Math.min(300, 1 << retryCount)));
 
     const downloadArtifact = async (artifact) => {
         let download = await github.rest.actions.downloadArtifact({
-            owner: context.repo.owner,
-            repo: context.repo.repo,
+            owner: owner,
+            repo: repo,
             artifact_id: artifact.id,
             archive_format: 'zip'
         });
@@ -15,8 +15,8 @@ module.exports = async ({github, context}, workflow_run_id, artifact_name_regex,
     };
 
     let artifactsAllOpts = github.rest.actions.listWorkflowRunArtifacts.endpoint.merge({
-        owner: context.repo.owner,
-        repo: context.repo.repo,
+        owner: owner,
+        repo: repo,
         run_id: workflow_run_id
     });
     let artifactsAll = await github.paginate(artifactsAllOpts);


### PR DESCRIPTION
The `download-github-workflow-artifact` action only supports downloading artifacts from the repo where a workflow uses it because users can't specify which repo to download actions from. This PR adds that ability.