### PR TITLE
Pin Python to 3.10

### DIFF
--- a/og/unit/action.yml
+++ b/og/unit/action.yml
@@ -12,7 +12,11 @@ inputs:
 
 runs:
   using: "composite"
-  steps:
+  steps:  
+    - uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+
     - run: | 
         eval `ssh-agent`
         echo "${{ inputs.key }}" | ssh-add -

--- a/og/unit/action.yml
+++ b/og/unit/action.yml
@@ -14,8 +14,8 @@ runs:
   using: "composite"
   steps:  
     - uses: actions/setup-python@v4
-        with:
-          python-version: '3.10'
+      with:
+        python-version: '3.10'
 
     - run: | 
         eval `ssh-agent`


### PR DESCRIPTION
Pins Python to version 3.10 globally for `OG` workflows