### PR TITLE
Add support for multiple PR numbers to GDIT action

### DIFF
--- a/generate-docker-image-tags/action.yml
+++ b/generate-docker-image-tags/action.yml
@@ -73,7 +73,7 @@ runs:
             -H "Accept: application/vnd.github+json" \
             -H "X-GitHub-Api-Version: 2022-11-28" \
             /repos/$GITHUB_REPOSITORY/commits/$SHA/pulls \
-            | jq -r ".[].number"
+            | jq -r ".[].number" | head -n 1
         )
 
         echo "PR number is '$PR_NUMBER'."


### PR DESCRIPTION
This PR adds support for multiple PR numbers in the GDIT action.

---

**Before**

```console
$ echo '[{"number": 1}, {"number": 2}]' | jq ".[].number"
1
2
$ echo '[{"number": 1}]' | jq ".[].number"
1
$ echo '[]' | jq ".[].number"
```

---

**After**

```console
$ echo '[{"number": 1}, {"number": 2}]' | jq ".[].number" | head -n 1
1
$ echo '[{"number": 1}]' | jq ".[].number" | head -n 1
1
$ echo '[]' | jq ".[].number" | head -n 1
```

---

This may not be the optimal solution to the problem, but it does prevent errors when multiple PRs are returned.