### PR TITLE
Fix `generate-docker-image-tags` API calls

### DIFF
--- a/generate-docker-image-tags/action.yml
+++ b/generate-docker-image-tags/action.yml
@@ -63,6 +63,7 @@ runs:
     - name: Get PR Number
       id: get-pr-number
       shell: bash
+      if: ${{ inputs.shortcut-api-token }}
       env:
         GITHUB_TOKEN: ${{ github.token }}
       run: |


### PR DESCRIPTION
Discovered while using this action without a shortcut token:
```
Run XanaduAI/cloud-actions/generate-docker-image-tags@v1.5.6
Run if [ "$GITHUB_EVENT_NAME" == "pull_request" ]
Branch is 'ci'.
SHA is '70ea076'.
Run SHA="70ea076"
  
gh: Resource not accessible by integration (HTTP 403)
jq: error (at <stdin>:0): Cannot index string with string "number"
```

## Changes
* Only execute `get-pr-number` if a shortcut token exists