### PR TITLE
Bump action fetches less files

### DIFF
--- a/og/bump/action.yml
+++ b/og/bump/action.yml
@@ -112,7 +112,7 @@ runs:
           non_bot_committers = filter(lambda x: "bot" not in x.lower().split(" "), committers)
 
           if any(non_bot_committers) and semver.compare(base_branch_ver, file_ver) == -1:
-              logger.warn(
+              logger.warning(
                 "Detected non bot commits to the version file, skipping version bump."
               )
               return str(file_ver)

--- a/og/bump/action.yml
+++ b/og/bump/action.yml
@@ -6,12 +6,11 @@ inputs:
   changelog_path:
     description: Explicit path to the changelog file.
     require: false
-    default: ''
+    default: ""
   version_template:
     description: Template for the version number to be added to the changelog file.
     requrie: false
     default: "v{}"
-
 
 runs:
   using: "composite"
@@ -19,13 +18,26 @@ runs:
     - name: Checkout
       uses: actions/checkout@v3
       with:
-        fetch-depth: 0
-        ref: "${{ github.head_ref }}"
+        ref: ${{ github.head_ref }}
+
+    - name: "Fetch full PR commit history"
+      env:
+        branch_base: origin/${{ github.event.pull_request.base.ref }}
+        branch_pr: origin/${{ github.event.pull_request.head.ref }}
+        refspec_base: +${{ github.event.pull_request.base.sha }}:remotes/origin/${{ github.event.pull_request.base.ref }}
+        refspec_pr: +${{ github.event.pull_request.head.sha }}:remotes/origin/${{ github.event.pull_request.head.ref }}
+      run: |
+        # Fetch enough history to find a common ancestor commit (aka merge-base):
+        git fetch origin ${{ env.refspec_pr }} --depth=$(( ${{ github.event.pull_request.commits }} + 1 )) \
+          --no-tags --prune --no-recurse-submodules
+
+        # Fetch most recent commit from pr base branch (for getting latest version number)
+        git fetch --no-tags --prune --no-recurse-submodules --depth=1 origin ${{ github.base_ref }}
 
     - name: Install semver
       run: python3 -m pip install semver
       shell: bash
-        
+
     - name: Run the main logic
       shell: python
       run: |

--- a/og/bump/action.yml
+++ b/og/bump/action.yml
@@ -23,9 +23,6 @@ runs:
     - name: "Fetch full PR commit history"
       shell: bash
       env:
-        branch_base: origin/${{ github.event.pull_request.base.ref }}
-        branch_pr: origin/${{ github.event.pull_request.head.ref }}
-        refspec_base: +${{ github.event.pull_request.base.sha }}:remotes/origin/${{ github.event.pull_request.base.ref }}
         refspec_pr: +${{ github.event.pull_request.head.sha }}:remotes/origin/${{ github.event.pull_request.head.ref }}
       run: |
         # Fetch enough history to find a common ancestor commit (aka merge-base):

--- a/og/bump/action.yml
+++ b/og/bump/action.yml
@@ -21,6 +21,7 @@ runs:
         ref: ${{ github.head_ref }}
 
     - name: "Fetch full PR commit history"
+      shell: bash
       env:
         branch_base: origin/${{ github.event.pull_request.base.ref }}
         branch_pr: origin/${{ github.event.pull_request.head.ref }}


### PR DESCRIPTION
### Summary
Tweaks the `actions/checkout` behavior in `cloud-actions/og/bump` to fetch the minimum number of commits required to do its job. Previously this was fetching all history for branches in the whole repo.
This action now only fetches:
- commits that are in the PR (a.k.a. the commits between base and target)
  - used to check for manual, non-bot commits to the version file
- the most-recent commit from the PRs base branch head 
  - to scrape a current version number

### Details
This change can save significant amounts of time during the checkout actions for large repos with many branches.
Additionally, it should no-longer be necessary to specify `fetch-depth: 0` in checkout actions that precede the shared `cloud-actions` (unless some other custom workflow step needs this full git history). The changes here were heavily based on [this comment](https://github.com/actions/checkout/issues/520#issuecomment-1167205721).

### References
See https://github.com/XanaduAI/gittagtest/pull/28 for tests

See real-world example on https://github.com/XanaduAI/chip-data-analysis/pull/196:
cloud-actions/bump@main : [job link](https://github.com/XanaduAI/chip-data-analysis/actions/runs/10222867182/job/28288216541#step:4:1) (1m38s)
cloud-actions/bump@bump_pulls_less_files: [job link](https://github.com/XanaduAI/chip-data-analysis/actions/runs/10224068267/job/28291327121#step:4:1) (3s)

### Notes
I would encourage testing this by temporarily pointing other real workflows (ideally before opening a PR) to this cloud-actions branch to confirm there aren't any unforeseen issues.

Additionally, for workflows where the `cloud-actions` are preceded by an `actions/checkout` action with a `fetch-depth: 0`, you will not see any time savings until the initial fetch-depth argument is removed. Multiple repos I looked at currently do this. I'd recommend removing this argument while doing the aforementioned test.

Last minor note, there is a node deprecation warning caused by `actions/checkout@v3`. I've tested this change using `v4` and had no issues, but bumping that dependency felt outside the scope of this already kinda complicated PR.