### PR TITLE
Update script to not paginate existing comments if a commentUid is not provided

### DIFF
--- a/create-and-update-pull-request-comment/comment.js
+++ b/create-and-update-pull-request-comment/comment.js
@@ -7,29 +7,33 @@ module.exports = async ({github, context}, prNumber, commentUid, commentBody) =>
     const commentContent = `${commentBody}\n${commentHeader}`;
     console.log(commentContent);
 
-    const opts = github.rest.issues.listComments.endpoint.merge({
-        owner: context.repo.owner,
-        repo: context.repo.repo,
-        issue_number: prNumber
-    });
-    const comments = await github.paginate(opts);
+    if (commentUid) {
+      const opts = github.rest.issues.listComments.endpoint.merge({
+          owner: context.repo.owner,
+          repo: context.repo.repo,
+          issue_number: prNumber
+      });
+      const comments = await github.paginate(opts);
 
-    // Find any comment already made by the bot.
-    const botComment = comments.find(comment => comment.user.id === actionsBotUserId && comment.body.trim().endsWith(commentHeader));
+      // Find any comment already made by the bot.
+      const botComment = comments.find(comment => comment.user.id === actionsBotUserId && comment.body.trim().endsWith(commentHeader));
 
-    if (botComment && commentUid) {
+      if (botComment) {
         await github.rest.issues.updateComment({
             owner: context.repo.owner,
             repo: context.repo.repo,
             comment_id: botComment.id,
             body: commentContent
         });
-    } else {
-        await github.rest.issues.createComment({
-            owner: context.repo.owner,
-            repo: context.repo.repo,
-            issue_number: prNumber,
-            body: commentContent
-        });
+
+        return;
+      }
     }
+
+    await github.rest.issues.createComment({
+        owner: context.repo.owner,
+        repo: context.repo.repo,
+        issue_number: prNumber,
+        body: commentContent
+    });
 }


### PR DESCRIPTION
This action is able to update an existing comment or create a new one each time.

However, even if the user opts in to create a new comment each time, it still scans all the comments on the PR and scans the body of the comments.

This is wasteful of network calls and unnecessarily slow for actions that need a new comment each time.

This PR updates the action such that if a commentUid is not passed (meaning create a new comment), then it skips the entire api call to fetch and scan existing comments and instantly creates a new one.