### PR TITLE
Allow external repo

### DIFF
--- a/create-and-update-pull-request-comment/action.yml
+++ b/create-and-update-pull-request-comment/action.yml
@@ -8,6 +8,18 @@ inputs:
   pull_request_number:
     description: The pull request number on which a comment needs to be added or updated
     required: true
+  repository_owner:
+    description: |
+      The owner of the repository where the pull request is located.
+      If omitted, the current repository owner that the action is running from is used.
+    required: false
+    default: ''
+  repository_name:
+    description: |
+      The name of the repository where the pull request is located.
+      If omitted, the current repository name that the action is running from is used.
+    required: false
+    default: ''
   comment_uid:
     description: |
       A Unique identifier to use to track a pinned comment. Can be set to an arbitrary value.
@@ -32,4 +44,9 @@ runs:
         github-token: ${{ inputs.github_token }}
         script: |
           const script = require('${{ github.action_path }}/comment.js');
-          await script({github, context}, ${{ inputs.pull_request_number }}, "${{ inputs.comment_uid }}", `${{ inputs.comment_body }}`);
+          await script({github, context},
+                       ${{ inputs.pull_request_number }},
+                      "${{ inputs.repository_owner }}",
+                      "${{ inputs.repository_name }}",
+                      "${{ inputs.comment_uid }}",
+                      `${{ inputs.comment_body }}`);

--- a/create-and-update-pull-request-comment/action.yml
+++ b/create-and-update-pull-request-comment/action.yml
@@ -18,6 +18,8 @@ inputs:
     description: |
       The name of the repository where the pull request is located.
       If omitted, the current repository name that the action is running from is used.
+
+      This can also be the full name of the repository in the format `owner/repo`. If this is provided, `repository_owner` is ignored.
     required: false
     default: ''
   comment_uid:

--- a/create-and-update-pull-request-comment/comment.js
+++ b/create-and-update-pull-request-comment/comment.js
@@ -3,8 +3,10 @@ module.exports = async ({github, context}, prNumber, repositoryOwner, repository
     // Sample Reference: https://github.com/orgs/community/discussions/26560
     const actionsBotUserId = 41898282;
 
-    const repository_owner = repositoryOwner || context.repo.owner;
-    const repository_name = repositoryName || context.repo.repo;
+    const { repository_owner, repository_name } = (repositoryName && repositoryName.includes('/')) ? repositoryName.split('/', 2) : [
+      repositoryOwner || context.repo.owner,
+      repositoryName || context.repo.repo
+    ];
 
     const commentHeader = `<!-- ${commentUid} -->`;
     const commentContent = `${commentBody}\n${commentHeader}`;

--- a/create-and-update-pull-request-comment/comment.js
+++ b/create-and-update-pull-request-comment/comment.js
@@ -7,29 +7,33 @@ module.exports = async ({github, context}, prNumber, commentUid, commentBody) =>
     const commentContent = `${commentBody}\n${commentHeader}`;
     console.log(commentContent);
 
-    const opts = github.rest.issues.listComments.endpoint.merge({
-        owner: context.repo.owner,
-        repo: context.repo.repo,
-        issue_number: prNumber
-    });
-    const comments = await github.paginate(opts);
+    if (commentUid) {
+      const opts = github.rest.issues.listComments.endpoint.merge({
+          owner: context.repo.owner,
+          repo: context.repo.repo,
+          issue_number: prNumber
+      });
+      const comments = await github.paginate(opts);
 
-    // Find any comment already made by the bot.
-    const botComment = comments.find(comment => comment.user.id === actionsBotUserId && comment.body.trim().endsWith(commentHeader));
+      // Find any comment already made by the bot.
+      const botComment = comments.find(comment => comment.user.id === actionsBotUserId && comment.body.trim().endsWith(commentHeader));
 
-    if (botComment && commentUid) {
+      if (botComment) {
         await github.rest.issues.updateComment({
             owner: context.repo.owner,
             repo: context.repo.repo,
             comment_id: botComment.id,
             body: commentContent
         });
-    } else {
-        await github.rest.issues.createComment({
-            owner: context.repo.owner,
-            repo: context.repo.repo,
-            issue_number: prNumber,
-            body: commentContent
-        });
+
+        return;
+      }
     }
+
+    await github.rest.issues.createComment({
+        owner: context.repo.owner,
+        repo: context.repo.repo,
+        issue_number: prNumber,
+        body: commentContent
+    });
 }

--- a/create-and-update-pull-request-comment/comment.js
+++ b/create-and-update-pull-request-comment/comment.js
@@ -1,7 +1,10 @@
-module.exports = async ({github, context}, prNumber, commentUid, commentBody) => {
+module.exports = async ({github, context}, prNumber, repositoryOwner, repositoryName, commentUid, commentBody) => {
     // Static User ID of the GitHub Actions Bot
     // Sample Reference: https://github.com/orgs/community/discussions/26560
     const actionsBotUserId = 41898282;
+
+    const repository_owner = repositoryOwner || context.repo.owner;
+    const repository_name = repositoryName || context.repo.repo;
 
     const commentHeader = `<!-- ${commentUid} -->`;
     const commentContent = `${commentBody}\n${commentHeader}`;
@@ -9,8 +12,8 @@ module.exports = async ({github, context}, prNumber, commentUid, commentBody) =>
 
     if (commentUid) {
       const opts = github.rest.issues.listComments.endpoint.merge({
-          owner: context.repo.owner,
-          repo: context.repo.repo,
+          owner: repository_owner,
+          repo: repository_name,
           issue_number: prNumber
       });
       const comments = await github.paginate(opts);
@@ -20,8 +23,8 @@ module.exports = async ({github, context}, prNumber, commentUid, commentBody) =>
 
       if (botComment) {
         await github.rest.issues.updateComment({
-            owner: context.repo.owner,
-            repo: context.repo.repo,
+            owner: repository_owner,
+            repo: repository_name,
             comment_id: botComment.id,
             body: commentContent
         });
@@ -31,8 +34,8 @@ module.exports = async ({github, context}, prNumber, commentUid, commentBody) =>
     }
 
     await github.rest.issues.createComment({
-        owner: context.repo.owner,
-        repo: context.repo.repo,
+        owner: repository_owner,
+        repo: repository_name,
         issue_number: prNumber,
         body: commentContent
     });


### PR DESCRIPTION
Currently the action only supports sending comments to the same repo the action runs in.

This PR adds capability to send comment to external repo (assuming the passed GITHUB_TOKEN has access).

