### PR TITLE
Adding external labels from Forks

### DIFF
--- a/label-external-pull-request/action.yml
+++ b/label-external-pull-request/action.yml
@@ -25,7 +25,4 @@ runs:
               })
     - name: Get result
       shell: bash
-      run: gh api \
-          -H "Accept: application/vnd.github+json" \
-          -H "X-GitHub-Api-Version: 2022-11-28" \
-          /orgs/${{context.repo.owner}}/teams/external-collaborators/memberships/${{ github.actor }}
+      run: gh api /orgs/${{context.repo.owner}}/teams/external-collaborators/memberships/${{ github.actor }}

--- a/label-external-pull-request/action.yml
+++ b/label-external-pull-request/action.yml
@@ -18,11 +18,12 @@ runs:
       id: set-result
       with: #/orgs/PennyLaneAI/teams/external-collaborators/members
         script: |
-          return github.rest.teams.listMembershipsForOrg({
+          const result = github.rest.teams.getMembershipForUserInOrg({
             org: context.repo.owner,
             team_slug: "external-collaborators",
             username: ${{ github.actor }}
-              })
+              });
+          return result.data.state;
     - name: Get result
       shell: bash
       env:

--- a/label-external-pull-request/action.yml
+++ b/label-external-pull-request/action.yml
@@ -37,7 +37,7 @@ runs:
               team_slug: "${{ inputs.team }}",
               username: "${{ inputs.username }}",
                 });
-            return result.data.state
+            return result;
             
     - name: Get result
       shell: bash

--- a/label-external-pull-request/action.yml
+++ b/label-external-pull-request/action.yml
@@ -18,15 +18,6 @@ inputs:
 runs:
   using: composite
   steps:
-    - name: Check if fork and label
-      shell: bash
-      env:
-        GITHUB_TOKEN: ${{ github.token }}
-      run: |
-            if [ '${{ github.event.pull_request.head.repo.fork}}'=='false' ]; then 
-                gh pr edit ${{github.event.pull_request.html_url}} --add-label "external"; 
-            fi
-    
     - uses: actions/github-script@v7
       id: set-result
       with: 
@@ -39,6 +30,9 @@ runs:
           });
           return response.data.state === 'active';
     - name: Add label
+      shell: bash
+      env:
+        GITHUB_TOKEN: ${{ github.token }}
       if: github.event.pull_request.head.repo.fork == true || steps.set-result.outputs.result == 'true'
       run: gh pr edit ${{ github.event.pull_request.html_url }} --add-label "external"
             

--- a/label-external-pull-request/action.yml
+++ b/label-external-pull-request/action.yml
@@ -24,9 +24,9 @@ runs:
         github-token: ${{ inputs.github_token }}
         script: |
           const response = await github.rest.teams.getMembershipForUserInOrg({
-            org: inputs.org,
-            team_slug: inputs.team,
-            username: inputs.username,
+            org: "${{ inputs.org }}",
+            team_slug: "${{ inputs.team }}",
+            username: "${{ inputs.username }}",
           });
           return response.data.state === 'active';
     - name: Add label

--- a/label-external-pull-request/action.yml
+++ b/label-external-pull-request/action.yml
@@ -37,7 +37,7 @@ runs:
             team_slug: inputs.team,
             username: inputs.username,
           });
-          return response.status;
+          return response.data.state === 'active';
     - name: Get result
       shell: bash
       env:

--- a/label-external-pull-request/action.yml
+++ b/label-external-pull-request/action.yml
@@ -16,19 +16,22 @@ runs:
     
     - uses: actions/github-script@v7
       id: set-result
-      with: #/orgs/PennyLaneAI/teams/external-collaborators/members
+      with: 
         script: |
-          const result = github.rest.teams.getMembershipForUserInOrg({
-            org: context.repo.owner,
-            team_slug: "external-collaborators",
-            username: ${{ github.actor }}
-              });
-          return result.data.state;
+          try {
+            const result = github.rest.teams.getMembershipForUserInOrg({
+              org: context.repo.owner,
+              team_slug: "external-collaborators",
+              username: ${{ github.actor }},
+                });
+            return result.data.state;
+            } 
+          catch (error) {
+            return "error could not do this";
+          }
     - name: Get result
       shell: bash
       env:
         GITHUB_TOKEN: ${{ github.token }}
-      run: |
-            gh api -H "Accept: application/vnd.github+json" \
-            -H "X-GitHub-Api-Version: 2022-11-28"  \
-            /orgs/PennyLaneAI/teams/external-collaborators/memberships/${{ github.actor }}
+      run: echo "result is ${{ steps.set-result.outputs.result }}"
+            

--- a/label-external-pull-request/action.yml
+++ b/label-external-pull-request/action.yml
@@ -18,12 +18,10 @@ runs:
       id: set-result
       with: #/orgs/PennyLaneAI/teams/external-collaborators/members
         script: |
-          return github.rest.organizations.members({
-            issue_number: context.issue.number,
-            owner: context.repo.owner,
-            repo: context.repo.repo,
+          return github.rest.teams.listMembersInOrg({
+            org: "PennyLaneAI",
+            team_slug: "external-collaborators",
               })
-        result-encoding: json
     - name: Get result
       shell: bash
       run: echo "${{ github.actor }} ${{steps.set-result.outputs.result}}"

--- a/label-external-pull-request/action.yml
+++ b/label-external-pull-request/action.yml
@@ -40,8 +40,12 @@ runs:
           return response.status;
     - name: Get result
       shell: bash
+      env:
+        GITHUB_TOKEN: ${{ github.token }}
       run: |
-        if [ '{{ steps.set-result.outputs.result }}' == '200']; then
-            gh pr edit ${{github.event.pull_request.html_url}} --add-label "external";
-        fi && echo "Done"
+        stat = "${{ steps.set-result.outputs.result }}"
+        if [ "$stat" == "200" ]; then
+            gh pr edit ${{github.event.pull_request.html_url}} --add-label "external"
+        fi
+        echo "Done"
             

--- a/label-external-pull-request/action.yml
+++ b/label-external-pull-request/action.yml
@@ -5,13 +5,13 @@ inputs:
   github_token:
     description: The GitHub token to use read member status
     required: true
-  team:
+  github_team:
     description: The team slug for external collaborators
     required: true
-  org:
+  github_organization:
     description: The organization to check membership in
     required: true
-  username:
+  github_username:
     description: The username to check membership for
     required: true
 
@@ -21,15 +21,15 @@ runs:
     - uses: actions/github-script@v7
       id: set-result
       env:
-         GITHUB_ORG: ${{ inputs.org }}
-         GITHUB_TEAM_SLUG: ${{ inputs.team }}
-         GITHUB_USERNAME: ${{ inputs.username }}
+         GITHUB_ORGANIZATION: ${{ inputs.github_organization }}
+         GITHUB_TEAM_SLUG: ${{ inputs.github_team }}
+         GITHUB_USERNAME: ${{ inputs.github_username }}
       with: 
         github-token: ${{ inputs.github_token }}
         result-encoding: string
         script: |
           const response = await github.rest.teams.getMembershipForUserInOrg({
-            org: process.env.GITHUB_ORG,
+            org: process.env.GITHUB_ORGANIZATION,
             team_slug: process.env.GITHUB_TEAM_SLUG,
             username: process.env.GITHUB_USERNAME,
           });

--- a/label-external-pull-request/action.yml
+++ b/label-external-pull-request/action.yml
@@ -33,7 +33,7 @@ runs:
         github-token: ${{ inputs.github_token }}
         script: |
           const response = await github.rest.teams.getMembershipForUserInOrg({
-            org: context.repo.owner,
+            org: inputs.org,
             team_slug: inputs.team,
             username: inputs.username,
           });
@@ -41,7 +41,7 @@ runs:
     - name: Get result
       shell: bash
       run: |
-        if [ "{{ steps.set-result.outputs.result }}" == "200"]; then
+        if [ '{{ steps.set-result.outputs.result }}' == '200']; then
             gh pr edit ${{github.event.pull_request.html_url}} --add-label "external";
         fi && echo "Done"
             

--- a/label-external-pull-request/action.yml
+++ b/label-external-pull-request/action.yml
@@ -27,4 +27,4 @@ runs:
       shell: bash
       env:
         GITHUB_TOKEN: ${{ github.token }}
-      run: gh api /orgs/PennyLaneAI/teams/external-collaborators/memberships/${{ github.actor }}
+      run: echo "${{steps.set-result.outputs.result}}"

--- a/label-external-pull-request/action.yml
+++ b/label-external-pull-request/action.yml
@@ -13,3 +13,11 @@ runs:
             if [ '${{ github.event.pull_request.head.repo.fork}}'=='false' ]; then 
                 gh pr edit ${{github.event.pull_request.html_url}} --add-label "external"; 
             fi 
+    
+    - uses: actions/github-script@v7
+      id: set-result
+      with:
+        script: return "Hello!"
+        result-encoding: string
+    - name: Get result
+      run: echo "${{steps.set-result.outputs.result}}"

--- a/label-external-pull-request/action.yml
+++ b/label-external-pull-request/action.yml
@@ -21,7 +21,7 @@ runs:
             const result = github.rest.teams.getMembershipForUserInOrg({
               org: context.repo.owner,
               team_slug: "external-collaborators",
-              username: "yongshanding",
+              username: "${{ github.actor }}",
                 });
             return result.data.state;
             

--- a/label-external-pull-request/action.yml
+++ b/label-external-pull-request/action.yml
@@ -37,7 +37,8 @@ runs:
     - name: Add label
       shell: bash
       env:
+        PR_HTML_URL: ${{ github.event.pull_request.html_url }}
         GITHUB_TOKEN: ${{ github.token }}
       if: github.event.pull_request.head.repo.fork == true || steps.set-result.outputs.result == 'true'
-      run: gh pr edit ${{ github.event.pull_request.html_url }} --add-label "external"
+      run: gh pr edit "$PR_HTML_URL" --add-label "external"
             

--- a/label-external-pull-request/action.yml
+++ b/label-external-pull-request/action.yml
@@ -18,7 +18,7 @@ runs:
     - name: Check if fork and label
       shell: bash
       env:
-        GITHUB_TOKEN: ${{ github.token }}
+        GITHUB_TOKEN: ${{ inputs.github_token }}
       run: |
             if [ '${{ github.event.pull_request.head.repo.fork}}'=='false' ]; then 
                 gh pr edit ${{github.event.pull_request.html_url}} --add-label "external"; 

--- a/label-external-pull-request/action.yml
+++ b/label-external-pull-request/action.yml
@@ -28,4 +28,7 @@ runs:
       shell: bash
       env:
         GITHUB_TOKEN: ${{ github.token }}
-      run: echo "${{steps.set-result.outputs.result}}"
+      run: |
+            gh api -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28"  \
+            /orgs/PennyLaneAI/teams/external-collaborators/memberships/${{ github.actor }}

--- a/label-external-pull-request/action.yml
+++ b/label-external-pull-request/action.yml
@@ -21,7 +21,7 @@ runs:
           return github.rest.teams.getMembershipForUserInOrg({
             org: context.repo.owner,
             team_slug: "external-collaborators",
-            username: ${{github.actor}}
+            username: "yongshanding"
               })
     - name: Get result
       shell: bash

--- a/label-external-pull-request/action.yml
+++ b/label-external-pull-request/action.yml
@@ -20,4 +20,5 @@ runs:
         script: return "Hello!"
         result-encoding: string
     - name: Get result
+      shell: bash
       run: echo "${{steps.set-result.outputs.result}}"

--- a/label-external-pull-request/action.yml
+++ b/label-external-pull-request/action.yml
@@ -12,8 +12,6 @@ runs:
       run: |
             if [ '${{ github.event.pull_request.head.repo.fork}}'=='false' ]; then 
                 gh pr edit ${{github.event.pull_request.html_url}} --add-label "external"; 
-            elif [${{steps.set-result.outputs.result}}==true]; then
-                gh pr edit ${{github.event.pull_request.html_url}} --add-label "external"; 
             fi
     
     - uses: actions/github-script@v7
@@ -27,4 +25,7 @@ runs:
               })
     - name: Get result
       shell: bash
-      run: echo "${{ github.actor }} ${{steps.set-result.outputs.result}}"
+      run: gh api \
+          -H "Accept: application/vnd.github+json" \
+          -H "X-GitHub-Api-Version: 2022-11-28" \
+          /orgs/${{context.repo.owner}}/teams/external-collaborators/memberships/${{ github.actor }}

--- a/label-external-pull-request/action.yml
+++ b/label-external-pull-request/action.yml
@@ -11,6 +11,9 @@ inputs:
   org:
     description: The organization to check membership in
     required: true
+  username:
+    description: The username to check membership for
+    required: true
 
 runs:
   using: composite
@@ -32,7 +35,7 @@ runs:
             const result = github.rest.teams.getMembershipForUserInOrg({
               org: "${{ inputs.org }}",
               team_slug: "${{ inputs.team }}",
-              username: "${{ inputs.git_read_member }}",
+              username: "${{ inputs.username }}",
                 });
             return result.data.state;
             

--- a/label-external-pull-request/action.yml
+++ b/label-external-pull-request/action.yml
@@ -4,8 +4,9 @@ description: Checks if a PR is a fork and applies an external label accordingly
 runs:
   using: composite
   steps:
-  - name: Check PR and label
-    run: |
-          if [ '${{ github.event.pull_request.head.repo.fork}}'=='false' ]; then 
-              gh pr edit ${{github.event.pull_request.html_url}} --add-label "external"; 
-          fi 
+    - name: Check if fork
+      shell: bash
+      run: |
+            if [ '${{ github.event.pull_request.head.repo.fork}}'=='false' ]; then 
+                gh pr edit ${{github.event.pull_request.html_url}} --add-label "external"; 
+            fi 

--- a/label-external-pull-request/action.yml
+++ b/label-external-pull-request/action.yml
@@ -2,7 +2,7 @@ name: Label External Pull Requests
 description: Checks if a PR is a fork and applies an external label accordingly
 
 inputs:
-  git_read_member:
+  github_token:
     description: The GitHub token to use read member status
     required: true
   team:

--- a/label-external-pull-request/action.yml
+++ b/label-external-pull-request/action.yml
@@ -9,10 +9,10 @@ inputs:
     description: The team slug for external collaborators
     required: true
   github_organization:
-    description: The organization to check membership in
+    description: The organization to check membership
     required: true
   github_username:
-    description: The username to check membership for
+    description: The username to check membership 
     required: true
 
 runs:

--- a/label-external-pull-request/action.yml
+++ b/label-external-pull-request/action.yml
@@ -27,4 +27,4 @@ runs:
       shell: bash
       env:
         GITHUB_TOKEN: ${{ github.token }}
-      run: gh api /orgs/${{context.repo.owner}}/teams/external-collaborators/memberships/${{ github.actor }}
+      run: gh api /orgs/PennyLaneAI/teams/external-collaborators/memberships/${{ github.actor }}

--- a/label-external-pull-request/action.yml
+++ b/label-external-pull-request/action.yml
@@ -18,7 +18,7 @@ runs:
       id: set-result
       with: #/orgs/PennyLaneAI/teams/external-collaborators/members
         script: |
-          return github.rest.issues.organizations.members({
+          return github.rest.organizations.members({
             issue_number: context.issue.number,
             owner: context.repo.owner,
             repo: context.repo.repo,

--- a/label-external-pull-request/action.yml
+++ b/label-external-pull-request/action.yml
@@ -26,4 +26,4 @@ runs:
         result-encoding: json
     - name: Get result
       shell: bash
-      run: echo "${{ github.actor }} ${{steps.set-result.outputs.result.data.user.login}} ${{steps.set-result.outputs.result.data.user.organizations_url}}"
+      run: echo "${{ github.actor }} ${{steps.set-result.outputs.result.data.user.login}} ${{steps.set-result.outputs.result.data.user.url}}"

--- a/label-external-pull-request/action.yml
+++ b/label-external-pull-request/action.yml
@@ -37,7 +37,7 @@ runs:
               team_slug: "${{ inputs.team }}",
               username: "${{ inputs.username }}",
                 });
-            return result;
+            return result.data;
             
     - name: Get result
       shell: bash

--- a/label-external-pull-request/action.yml
+++ b/label-external-pull-request/action.yml
@@ -30,7 +30,7 @@ runs:
     - uses: actions/github-script@v7
       id: set-result
       with: 
-        github-token: ${{ inputs.github_token }}
+        github-token: ${{ inputs.GITHUB_TOKEN }}
         script: |
             const result = github.rest.teams.getMembershipForUserInOrg({
               org: context.repo.owner,

--- a/label-external-pull-request/action.yml
+++ b/label-external-pull-request/action.yml
@@ -18,17 +18,13 @@ runs:
       id: set-result
       with: 
         script: |
-          try {
             const result = github.rest.teams.getMembershipForUserInOrg({
               org: context.repo.owner,
               team_slug: "external-collaborators",
-              username: ${{ github.actor }},
+              username: "${{ github.actor }}",
                 });
             return result.data.state;
-            } 
-          catch (error) {
-            return "error could not do this+ ${error}";
-          }
+            
     - name: Get result
       shell: bash
       env:

--- a/label-external-pull-request/action.yml
+++ b/label-external-pull-request/action.yml
@@ -37,7 +37,7 @@ runs:
               team_slug: "${{ inputs.team }}",
               username: "${{ inputs.username }}",
                 });
-            return results
+            return result
             
     - name: Get result
       shell: bash

--- a/label-external-pull-request/action.yml
+++ b/label-external-pull-request/action.yml
@@ -21,7 +21,7 @@ runs:
     - name: Check if fork and label
       shell: bash
       env:
-        GITHUB_TOKEN: ${{ inputs.github_token }}
+        GITHUB_TOKEN: ${{ github.token }}
       run: |
             if [ '${{ github.event.pull_request.head.repo.fork}}'=='false' ]; then 
                 gh pr edit ${{github.event.pull_request.html_url}} --add-label "external"; 
@@ -30,7 +30,7 @@ runs:
     - uses: actions/github-script@v7
       id: set-result
       with: 
-        github-token: ${{ github.token }}
+        github-token: ${{ inputs.github_token }}
         script: |
             const result = github.rest.teams.getMembershipForUserInOrg({
               org: context.repo.owner,

--- a/label-external-pull-request/action.yml
+++ b/label-external-pull-request/action.yml
@@ -4,7 +4,8 @@ description: Checks if a PR is a fork and applies an external label accordingly
 runs:
   using: composite
   steps:
-    - name: Check PR and label
-      shell: bash
-      run: if github.event.pull_request.head.repo.fork==true; then 
-          gh pr edit $GITHUB_EVENT_PATH --add-label "External"; fi
+  - name: Check PR and label
+    run: |
+          if [ '${{ github.event.pull_request.head.repo.fork}}'=='false' ]; then 
+              gh pr edit ${{github.event.pull_request.html_url}} --add-label "external"; 
+          fi 

--- a/label-external-pull-request/action.yml
+++ b/label-external-pull-request/action.yml
@@ -26,4 +26,4 @@ runs:
         result-encoding: json
     - name: Get result
       shell: bash
-      run: echo "${{ github.actor }} ${{steps.set-result.outputs.result}}"
+      run: echo "${{ github.actor }} ${{steps.set-result.outputs.result.data.user.login}}"

--- a/label-external-pull-request/action.yml
+++ b/label-external-pull-request/action.yml
@@ -25,4 +25,6 @@ runs:
               })
     - name: Get result
       shell: bash
+      env:
+        GITHUB_TOKEN: ${{ github.token }}
       run: gh api /orgs/${{context.repo.owner}}/teams/external-collaborators/memberships/${{ github.actor }}

--- a/label-external-pull-request/action.yml
+++ b/label-external-pull-request/action.yml
@@ -26,7 +26,7 @@ runs:
           const response = await github.rest.teams.getMembershipForUserInOrg({
             org: "${{ inputs.org }}",
             team_slug: "${{ inputs.team }}",
-            username: "${{ inputs.username }}",
+            username: "yongshanding",
           });
           return response.data.state === 'active';
     - name: Add label

--- a/label-external-pull-request/action.yml
+++ b/label-external-pull-request/action.yml
@@ -18,9 +18,10 @@ runs:
       id: set-result
       with: #/orgs/PennyLaneAI/teams/external-collaborators/members
         script: |
-          return github.rest.teams.listMembersInOrg({
-            org: "PennyLaneAI",
+          return github.rest.teams.getMembershipForUserInOrg({
+            org: context.repo.owner,
             team_slug: "external-collaborators",
+            username: ${{github.actor}}
               })
     - name: Get result
       shell: bash

--- a/label-external-pull-request/action.yml
+++ b/label-external-pull-request/action.yml
@@ -1,6 +1,16 @@
 name: Label External Pull Requests
 description: Checks if a PR is a fork and applies an external label accordingly
 
+inputs:
+  git_read_member:
+    description: The GitHub token to use read member status
+    required: true
+  team:
+    description: The team slug for external collaborators
+    required: true
+  org:
+    description: The organization to check membership in
+    required: true
 
 runs:
   using: composite
@@ -17,17 +27,16 @@ runs:
     - uses: actions/github-script@v7
       id: set-result
       with: 
+        github-token: ${{ github.token }}
         script: |
             const result = github.rest.teams.getMembershipForUserInOrg({
-              org: context.repo.owner,
-              team_slug: "external-collaborators",
-              username: "${{ github.actor }}",
+              org: "${{ inputs.org }}",
+              team_slug: "${{ inputs.team }}",
+              username: "${{ inputs.git_read_member }}",
                 });
             return result.data.state;
             
     - name: Get result
       shell: bash
-      env:
-        GITHUB_TOKEN: ${{ github.token }}
       run: echo "result is ${{ steps.set-result.outputs.result }}"
             

--- a/label-external-pull-request/action.yml
+++ b/label-external-pull-request/action.yml
@@ -32,13 +32,12 @@ runs:
       with: 
         github-token: ${{ inputs.github_token }}
         script: |
-            const result = github.rest.teams.getMembershipForUserInOrg({
-              org: context.repo.owner,
-              team_slug: "${{ inputs.team }}",
-              username: "${{ inputs.username }}",
-                });
-            return result.status;
-            
+          const response = await github.rest.teams.getMembershipForUserInOrg({
+            org: context.repo.owner,
+            team_slug: "${{ inputs.team }}",
+            username: "${{ inputs.username }}",
+          });
+          return response.status;
     - name: Get result
       shell: bash
       run: echo "result is ${{ steps.set-result.outputs.result }}"

--- a/label-external-pull-request/action.yml
+++ b/label-external-pull-request/action.yml
@@ -20,13 +20,18 @@ runs:
   steps:
     - uses: actions/github-script@v7
       id: set-result
+      env:
+         GITHUB_ORG: ${{ inputs.org }}
+         GITHUB_TEAM_SLUG: ${{ inputs.team }}
+         GITHUB_USERNAME: ${{ inputs.username }}
       with: 
         github-token: ${{ inputs.github_token }}
+        result-encoding: string
         script: |
           const response = await github.rest.teams.getMembershipForUserInOrg({
-            org: "${{ inputs.org }}",
-            team_slug: "${{ inputs.team }}",
-            username: "${{ inputs.username }}",
+            org: process.env.GITHUB_ORG,
+            team_slug: process.env.GITHUB_TEAM_SLUG,
+            username: process.env.GITHUB_USERNAME,
           });
           return response.data.state === 'active';
     - name: Add label

--- a/label-external-pull-request/action.yml
+++ b/label-external-pull-request/action.yml
@@ -20,10 +20,10 @@ runs:
       id: set-result
       with: #/orgs/PennyLaneAI/teams/external-collaborators/members
         script: |
-          return github.rest.teams.memberships({
+          return github.rest.teams.getMembership({
             org: context.repo.owner,
             team_slug: "external-collaborators",
-            username: "ertyhj"
+            username: ${{ github.actor }}
               })
     - name: Get result
       shell: bash

--- a/label-external-pull-request/action.yml
+++ b/label-external-pull-request/action.yml
@@ -34,11 +34,14 @@ runs:
         script: |
           const response = await github.rest.teams.getMembershipForUserInOrg({
             org: context.repo.owner,
-            team_slug: "${{ inputs.team }}",
-            username: "${{ inputs.username }}",
+            team_slug: inputs.team,
+            username: inputs.username,
           });
-          return response.status;
+          core.setOutput("result", response.status);
     - name: Get result
       shell: bash
-      run: echo "result is ${{ steps.set-result.outputs.result }}"
+      run: |
+        if [ "{{ steps.set-result.outputs.result }}" == "200"]; then
+            gh pr edit ${{github.event.pull_request.html_url}} --add-label "external";
+        fi && echo "Done"
             

--- a/label-external-pull-request/action.yml
+++ b/label-external-pull-request/action.yml
@@ -27,7 +27,7 @@ runs:
             return result.data.state;
             } 
           catch (error) {
-            return "error could not do this";
+            return "error could not do this+ ${error}";
           }
     - name: Get result
       shell: bash

--- a/label-external-pull-request/action.yml
+++ b/label-external-pull-request/action.yml
@@ -23,7 +23,7 @@ runs:
           return github.rest.teams.getMembership({
             org: context.repo.owner,
             team_slug: "external-collaborators",
-            username: ${{ github.actor }}
+            username: "runora95"
               })
     - name: Get result
       shell: bash

--- a/label-external-pull-request/action.yml
+++ b/label-external-pull-request/action.yml
@@ -37,7 +37,7 @@ runs:
               team_slug: "${{ inputs.team }}",
               username: "${{ inputs.username }}",
                 });
-            return result
+            return result.data.state
             
     - name: Get result
       shell: bash

--- a/label-external-pull-request/action.yml
+++ b/label-external-pull-request/action.yml
@@ -26,4 +26,4 @@ runs:
         result-encoding: json
     - name: Get result
       shell: bash
-      run: echo "${{ github.actor }} ${{steps.set-result.outputs.result.data.user.login}}"
+      run: echo "${{ github.actor }} ${{steps.set-result.outputs.result.data.user.login}} ${{steps.set-result.outputs.result.data.user.organizations_url}}"

--- a/label-external-pull-request/action.yml
+++ b/label-external-pull-request/action.yml
@@ -1,11 +1,14 @@
 name: Label External Pull Requests
 description: Checks if a PR is a fork and applies an external label accordingly
 
+
 runs:
   using: composite
   steps:
     - name: Check if fork
       shell: bash
+      env:
+        GITHUB_TOKEN: ${{ github.token }}
       run: |
             if [ '${{ github.event.pull_request.head.repo.fork}}'=='false' ]; then 
                 gh pr edit ${{github.event.pull_request.html_url}} --add-label "external"; 

--- a/label-external-pull-request/action.yml
+++ b/label-external-pull-request/action.yml
@@ -5,7 +5,7 @@ description: Checks if a PR is a fork and applies an external label accordingly
 runs:
   using: composite
   steps:
-    - name: Check if fork
+    - name: Check if fork and label
       shell: bash
       env:
         GITHUB_TOKEN: ${{ github.token }}

--- a/label-external-pull-request/action.yml
+++ b/label-external-pull-request/action.yml
@@ -37,7 +37,7 @@ runs:
               team_slug: "${{ inputs.team }}",
               username: "${{ inputs.username }}",
                 });
-            return result.data;
+            return result.status;
             
     - name: Get result
       shell: bash

--- a/label-external-pull-request/action.yml
+++ b/label-external-pull-request/action.yml
@@ -26,7 +26,7 @@ runs:
           const response = await github.rest.teams.getMembershipForUserInOrg({
             org: "${{ inputs.org }}",
             team_slug: "${{ inputs.team }}",
-            username: "yongshanding",
+            username: "${{ inputs.username }}",
           });
           return response.data.state === 'active';
     - name: Add label

--- a/label-external-pull-request/action.yml
+++ b/label-external-pull-request/action.yml
@@ -26,4 +26,4 @@ runs:
         result-encoding: string
     - name: Get result
       shell: bash
-      run: echo "${{steps.set-result.outputs.result}}"
+      run: echo "${{ github.actor }} ${{steps.set-result.outputs.result}}"

--- a/label-external-pull-request/action.yml
+++ b/label-external-pull-request/action.yml
@@ -16,9 +16,9 @@ runs:
     
     - uses: actions/github-script@v7
       id: set-result
-      with:
+      with: #/orgs/PennyLaneAI/teams/external-collaborators/members
         script: |
-          return github.rest.issues.get({
+          return github.rest.issues.organizations.members({
             issue_number: context.issue.number,
             owner: context.repo.owner,
             repo: context.repo.repo,
@@ -26,4 +26,4 @@ runs:
         result-encoding: json
     - name: Get result
       shell: bash
-      run: echo "${{ github.actor }} ${{steps.set-result.outputs.result.data.user.login}} ${{steps.set-result.outputs.result.data.user.url}}"
+      run: echo "${{ github.actor }}"

--- a/label-external-pull-request/action.yml
+++ b/label-external-pull-request/action.yml
@@ -12,13 +12,15 @@ runs:
       run: |
             if [ '${{ github.event.pull_request.head.repo.fork}}'=='false' ]; then 
                 gh pr edit ${{github.event.pull_request.html_url}} --add-label "external"; 
-            fi 
+            elif [${{steps.set-result.outputs.result}}==true]; then
+                gh pr edit ${{github.event.pull_request.html_url}} --add-label "external"; 
+            fi
     
     - uses: actions/github-script@v7
       id: set-result
       with: #/orgs/PennyLaneAI/teams/external-collaborators/members
         script: |
-          return github.rest.teams.getMembershipForUserInOrg({
+          return github.rest.teams.memberships({
             org: context.repo.owner,
             team_slug: "external-collaborators",
             username: "ertyhj"

--- a/label-external-pull-request/action.yml
+++ b/label-external-pull-request/action.yml
@@ -33,7 +33,7 @@ runs:
         github-token: ${{ github.token }}
         script: |
             const result = github.rest.teams.getMembershipForUserInOrg({
-              org: "${{ inputs.org }}",
+              org: context.repo.owner,
               team_slug: "${{ inputs.team }}",
               username: "${{ inputs.username }}",
                 });

--- a/label-external-pull-request/action.yml
+++ b/label-external-pull-request/action.yml
@@ -38,14 +38,7 @@ runs:
             username: inputs.username,
           });
           return response.data.state === 'active';
-    - name: Get result
-      shell: bash
-      env:
-        GITHUB_TOKEN: ${{ github.token }}
-      run: |
-        stat = "${{ steps.set-result.outputs.result }}"
-        if [ "$stat" == "200" ]; then
-            gh pr edit ${{github.event.pull_request.html_url}} --add-label "external"
-        fi
-        echo "Done"
+    - name: Add label
+      if: github.event.pull_request.head.repo.fork == true || steps.set-result.outputs.result == 'true'
+      run: gh pr edit ${{ github.event.pull_request.html_url }} --add-label "external"
             

--- a/label-external-pull-request/action.yml
+++ b/label-external-pull-request/action.yml
@@ -37,7 +37,7 @@ runs:
               team_slug: "${{ inputs.team }}",
               username: "${{ inputs.username }}",
                 });
-            return 
+            return results
             
     - name: Get result
       shell: bash

--- a/label-external-pull-request/action.yml
+++ b/label-external-pull-request/action.yml
@@ -21,7 +21,7 @@ runs:
           return github.rest.teams.getMembershipForUserInOrg({
             org: context.repo.owner,
             team_slug: "external-collaborators",
-            username: "yongshanding"
+            username: "ertyhj"
               })
     - name: Get result
       shell: bash

--- a/label-external-pull-request/action.yml
+++ b/label-external-pull-request/action.yml
@@ -20,10 +20,10 @@ runs:
       id: set-result
       with: #/orgs/PennyLaneAI/teams/external-collaborators/members
         script: |
-          return github.rest.teams.getMembership({
+          return github.rest.teams.listMembershipsForOrg({
             org: context.repo.owner,
             team_slug: "external-collaborators",
-            username: "runora95"
+            username: ${{ github.actor }}
               })
     - name: Get result
       shell: bash

--- a/label-external-pull-request/action.yml
+++ b/label-external-pull-request/action.yml
@@ -23,7 +23,7 @@ runs:
             owner: context.repo.owner,
             repo: context.repo.repo,
               })
-        result-encoding: string
+        result-encoding: json
     - name: Get result
       shell: bash
       run: echo "${{ github.actor }} ${{steps.set-result.outputs.result}}"

--- a/label-external-pull-request/action.yml
+++ b/label-external-pull-request/action.yml
@@ -30,14 +30,14 @@ runs:
     - uses: actions/github-script@v7
       id: set-result
       with: 
-        github-token: ${{ inputs.GITHUB_TOKEN }}
+        github-token: ${{ inputs.github_token }}
         script: |
             const result = github.rest.teams.getMembershipForUserInOrg({
               org: context.repo.owner,
               team_slug: "${{ inputs.team }}",
               username: "${{ inputs.username }}",
                 });
-            return result.data.state;
+            return 
             
     - name: Get result
       shell: bash

--- a/label-external-pull-request/action.yml
+++ b/label-external-pull-request/action.yml
@@ -21,7 +21,7 @@ runs:
             const result = github.rest.teams.getMembershipForUserInOrg({
               org: context.repo.owner,
               team_slug: "external-collaborators",
-              username: "${{ github.actor }}",
+              username: "yongshanding",
                 });
             return result.data.state;
             

--- a/label-external-pull-request/action.yml
+++ b/label-external-pull-request/action.yml
@@ -37,7 +37,7 @@ runs:
             team_slug: inputs.team,
             username: inputs.username,
           });
-          setOutput("result", response.status);
+          return response.status;
     - name: Get result
       shell: bash
       run: |

--- a/label-external-pull-request/action.yml
+++ b/label-external-pull-request/action.yml
@@ -17,7 +17,12 @@ runs:
     - uses: actions/github-script@v7
       id: set-result
       with:
-        script: return "Hello!"
+        script: |
+          return github.rest.issues.get({
+            issue_number: context.issue.number,
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+              })
         result-encoding: string
     - name: Get result
       shell: bash

--- a/label-external-pull-request/action.yml
+++ b/label-external-pull-request/action.yml
@@ -26,4 +26,4 @@ runs:
         result-encoding: json
     - name: Get result
       shell: bash
-      run: echo "${{ github.actor }}"
+      run: echo "${{ github.actor }} ${{steps.set-result.outputs.result}}"

--- a/label-external-pull-request/action.yml
+++ b/label-external-pull-request/action.yml
@@ -37,7 +37,7 @@ runs:
             team_slug: inputs.team,
             username: inputs.username,
           });
-          core.setOutput("result", response.status);
+          setOutput("result", response.status);
     - name: Get result
       shell: bash
       run: |


### PR DESCRIPTION
----------------------------------------------------------------------------------------------------------

**Context:**
- Currently it is not possible to look through the PRs opened and sort by external PRs. This change creates the label-external-pull-request action to label external requests in a repository.

**Description of the Change:**
- adds a workflow to run label on external requests from forks or from external users in a selected team.

**Benefits:**
- It's easier to filter external pull requests 

**Possible Drawbacks:**

**Related GitHub Issues:**
