### PR TITLE
Fix flake8 output visibility issue and ignores E226 and E227

### DIFF
--- a/og/lint/action.yml
+++ b/og/lint/action.yml
@@ -9,8 +9,8 @@ runs:
       shell: bash
       run: | 
           pip install black isort docformatter flake8
-          black ./rpdaq/ ./tests/
-          flake8 --ignore=E203,E501,W503 ./rpdaq/ ./tests/
+          # black ./rpdaq/ ./tests/
+          # flake8 --ignore=E203,E501,W503 ./rpdaq/ ./tests/
 
     - name: Run the main logic
       shell: python
@@ -44,11 +44,11 @@ runs:
           files_to_format = edited_py_files - ignore_files
 
           if files_to_format := " ".join(map(str, files_to_format)):
-            print("Running black...")
+            print("Running black...", flush=True)
             subprocess.run(f"black {files_to_format}", shell=True, check=True)
-            print("Running isort...")
+            print("Running isort...", flush=True)
             subprocess.run(f"isort --profile=black {files_to_format}", shell=True)
-            print("Running docformatter")
+            print("Running docformatter", flush=True)
             if (
               subprocess.run(
                 f"docformatter --recursive --in-place --wrap-summaries 88 --wrap-descriptions 88 {files_to_format}",
@@ -56,8 +56,8 @@ runs:
               ).returncode
               == 3
             ):
-              print("Docformatter raised status 3")
-            print("Running flake8")
+              print("Docformatter raised status 3", flush=True)
+            print("Running flake8", flush=True)
             subprocess.run(
-              f"flake8 --ignore=E203,E501,W503 {files_to_format}", shell=True, check=not True
+              f"flake8 --ignore=E203,E501,W503 {files_to_format}", shell=True, check=True
             )

--- a/og/lint/action.yml
+++ b/og/lint/action.yml
@@ -43,7 +43,7 @@ runs:
 
           if files_to_format := " ".join(map(str, files_to_format)):
             print("Running black...")
-            subprocess.run(f"black {files_to_format}", shell=True)
+            subprocess.run(f"black {files_to_format}", shell=True, check=True)
             print("Running isort...")
             subprocess.run(f"isort --profile=black {files_to_format}", shell=True)
             print("Running docformatter")

--- a/og/lint/action.yml
+++ b/og/lint/action.yml
@@ -60,5 +60,6 @@ runs:
               subprocess.run(
                 f"flake8 --ignore=E203,E501,W503 {files_to_format}", shell=True, check=True
               )
-            finally:
-              print("Ling action finished!", flush=True)
+            except Exception:
+              print("Lint action finished with an exception:", flush=True)
+              raise

--- a/og/lint/action.yml
+++ b/og/lint/action.yml
@@ -9,7 +9,9 @@ runs:
       shell: bash
       run: | 
           pip install black isort docformatter flake8
-      
+          black ./rpdaq/ ./tests/
+          flake8 --ignore=E203,E501,W503 ./rpdaq/ ./tests/
+
     - name: Run the main logic
       shell: python
       run: |
@@ -57,5 +59,5 @@ runs:
               print("Docformatter raised status 3")
             print("Running flake8")
             subprocess.run(
-              f"flake8 --ignore=E203,E501,W503 {files_to_format}", shell=True, check=True
+              f"flake8 --ignore=E203,E501,W503 {files_to_format}", shell=True, check=not True
             )

--- a/og/lint/action.yml
+++ b/og/lint/action.yml
@@ -58,7 +58,7 @@ runs:
                 print("Docformatter raised status 3", flush=True)
               print("Running flake8", flush=True)
               subprocess.run(
-                f"flake8 --ignore=E203,E501,W503 {files_to_format}", shell=True, check=True
+                f"flake8 --ignore=E203,E226,E227,E501,W503, {files_to_format}", shell=True, check=True
               )
             except Exception:
               print("Lint action finished with an exception:", flush=True)

--- a/og/lint/action.yml
+++ b/og/lint/action.yml
@@ -9,8 +9,6 @@ runs:
       shell: bash
       run: | 
           pip install black isort docformatter flake8
-          # black ./rpdaq/ ./tests/
-          # flake8 --ignore=E203,E501,W503 ./rpdaq/ ./tests/
 
     - name: Run the main logic
       shell: python
@@ -46,7 +44,7 @@ runs:
           if files_to_format := " ".join(map(str, files_to_format)):
             try:
               print("Running black...", flush=True)
-              subprocess.run(f"black {files_to_format}", shell=True, check=True)
+              subprocess.run(f"black {files_to_format}", shell=True)
               print("Running isort...", flush=True)
               subprocess.run(f"isort --profile=black {files_to_format}", shell=True)
               print("Running docformatter", flush=True)

--- a/og/lint/action.yml
+++ b/og/lint/action.yml
@@ -44,20 +44,23 @@ runs:
           files_to_format = edited_py_files - ignore_files
 
           if files_to_format := " ".join(map(str, files_to_format)):
-            print("Running black...", flush=True)
-            subprocess.run(f"black {files_to_format}", shell=True, check=True)
-            print("Running isort...", flush=True)
-            subprocess.run(f"isort --profile=black {files_to_format}", shell=True)
-            print("Running docformatter", flush=True)
-            if (
+            try:
+              print("Running black...", flush=True)
+              subprocess.run(f"black {files_to_format}", shell=True, check=True)
+              print("Running isort...", flush=True)
+              subprocess.run(f"isort --profile=black {files_to_format}", shell=True)
+              print("Running docformatter", flush=True)
+              if (
+                subprocess.run(
+                  f"docformatter --recursive --in-place --wrap-summaries 88 --wrap-descriptions 88 {files_to_format}",
+                  shell=True,
+                ).returncode
+                == 3
+              ):
+                print("Docformatter raised status 3", flush=True)
+              print("Running flake8", flush=True)
               subprocess.run(
-                f"docformatter --recursive --in-place --wrap-summaries 88 --wrap-descriptions 88 {files_to_format}",
-                shell=True,
-              ).returncode
-              == 3
-            ):
-              print("Docformatter raised status 3", flush=True)
-            print("Running flake8", flush=True)
-            subprocess.run(
-              f"flake8 --ignore=E203,E501,W503 {files_to_format}", shell=True, check=True
-            )
+                f"flake8 --ignore=E203,E501,W503 {files_to_format}", shell=True, check=True
+              )
+            finally:
+              print("Ling action finished!", flush=True)


### PR DESCRIPTION
This PR
- improves the readability of the OG lint workflow output by forcing it to be displayed completely, and with mixups between different subprocesses, and
- has flake8 ignore E226 (missing whitespace around arithmetic operator) and E227 (missing whitespace around bitwise or shift operator) because black is unable to auto-fix such issues inside f-strings. flake8 did not care until python 3.12 about these issues. Once black can handle expressions inside f-strings we can drop E226/7 from the ignore-list again.