### PR TITLE
Pin docformatter version to 1.7.7 in action.yml

### DIFF
--- a/og/lint/action.yml
+++ b/og/lint/action.yml
@@ -8,7 +8,7 @@ runs:
     - name: Install dependencies
       shell: bash
       run: | 
-          pip install black isort docformatter flake8
+          pip install black isort docformatter==1.7.7 flake8
 
     - name: Run the main logic
       shell: python


### PR DESCRIPTION
Pins docformatter in og lint workflows to avoid E302 errors until they fix their code